### PR TITLE
Added Embargo Decisions

### DIFF
--- a/common/decisions/embargo.txt
+++ b/common/decisions/embargo.txt
@@ -1,0 +1,211 @@
+political_actions = {
+	USA_Embargo_JAP = {
+		icon = generic_political_discourse
+		available = {
+			tag = USA
+			JAP = {
+				has_completed_focus = JAP_secure_china
+			}
+		}
+		visible = {
+			tag = USA
+			NOT = { has_government = JAP }
+			NOT = { has_war_with = JAP }
+		}
+		cost = 75
+		ai_will_do = {
+			factor = 100
+		}
+		fire_only_once = yes
+		complete_effect = {
+			USA = {
+				add_opinion_modifier = {
+					target = JAP
+					modifier = embargo
+				}
+				reverse_add_opinion_modifier = {
+					target = JAP
+					modifier = embargo
+				}
+				set_country_flag = USA_Embargo_JAP
+			}
+		}
+	}
+	Americas_Embargo_JAP = {
+		icon = generic_political_discourse
+		available = {
+			tag = USA
+			has_country_flag = USA_Embargo_JAP
+			JAP = {
+				has_completed_focus = JAP_secure_china
+			}
+		}
+		visible = {
+			tag = USA
+			has_country_flag = USA_Embargo_JAP
+			NOT = { has_government = JAP }
+		}
+		cost = 75
+		ai_will_do = {
+			factor = 100
+		}
+		fire_only_once = yes
+		complete_effect = {
+			USA = {
+				every_other_country = {
+					limit = {
+						capital_scope = {
+							OR = {
+								is_on_continent = north_america
+								is_on_continent = south_america
+							}
+						}
+					}
+					country_event = {
+						id = embargo.1	
+						days = 2
+						random = 24
+					}
+				}
+			}
+		}
+	}
+
+	ENG_Embargo_JAP = {
+		icon = generic_political_discourse
+		available = {
+			tag = ENG
+			JAP = {
+				has_completed_focus = JAP_secure_china
+			}
+		}
+		visible = {
+			tag = ENG
+			NOT = { has_government = JAP }
+			NOT = { has_war_with = JAP }
+		}
+		cost = 75
+		ai_will_do = {
+			factor = 100
+		}
+		fire_only_once = yes
+		complete_effect = {
+			ENG = {
+				add_opinion_modifier = {
+					target = JAP
+					modifier = embargo
+				}
+				reverse_add_opinion_modifier = {
+					target = JAP
+					modifier = embargo
+				}
+				set_country_flag = ENG_Embargo_JAP
+			}
+		}
+	}
+	Allies_Embargo_JAP = {
+		icon = generic_political_discourse
+		available = {
+			tag = ENG
+			has_country_flag = ENG_Embargo_JAP
+			JAP = {
+				has_completed_focus = JAP_secure_china
+			}
+		}
+		visible = {
+			tag = ENG
+			has_country_flag = ENG_Embargo_JAP
+			NOT = { has_government = JAP }
+		}
+		cost = 75
+		ai_will_do = {
+			factor = 100
+		}
+		fire_only_once = yes
+		complete_effect = {
+			ENG = {
+				every_other_country = {
+					limit = {
+						is_in_faction_with = ROOT
+					}
+					country_event = {
+						id = embargo.1	
+						days = 2
+						random = 24
+					}
+				}
+			}
+		}
+	}
+	USA_Embargo_GER = {
+		icon = generic_political_discourse
+		available = {
+			tag = USA
+			GER = {
+				has_war_with = ENG
+			}
+		}
+		visible = {
+			tag = USA
+			NOT = { has_government = GER }
+			NOT = { has_war_with = GER }
+		}
+		cost = 75
+		ai_will_do = {
+			factor = 100
+		}
+		fire_only_once = yes
+		complete_effect = {
+			USA = {
+				add_opinion_modifier = {
+					target = GER
+					modifier = embargo
+				}
+				reverse_add_opinion_modifier = {
+					target = GER
+					modifier = embargo
+				}
+				set_country_flag = USA_Embargo
+			}
+		}
+	}
+	Americas_Embargo_GER = {
+		icon = generic_political_discourse
+		available = {
+			tag = USA
+			has_country_flag = USA_Embargo_GER
+			GER = {
+				has_war_with = ENG
+			}
+		}
+		visible = {
+			tag = USA
+			has_country_flag = USA_Embargo_GER
+			NOT = { has_government = GER }
+		}
+		cost = 75
+		ai_will_do = {
+			factor = 100
+		}
+		fire_only_once = yes
+		complete_effect = {
+			USA = {
+				every_other_country = {
+					limit = {
+						capital_scope = {
+							OR = {
+								is_on_continent = north_america
+								is_on_continent = south_america
+							}
+						}
+					}
+					country_event = {
+						id = embargo.1	
+						days = 2
+						random = 24
+					}
+				}
+			}
+		}
+	}
+}

--- a/common/decisions/foreign_influence.txt
+++ b/common/decisions/foreign_influence.txt
@@ -1,0 +1,516 @@
+foreign_influence = {
+
+	# Decisions for masters to push their ideology onto puppets
+	# Note that subject status is not checked due to those only appearing in DLC
+	# (Subjects are puppets with high autonomy)
+
+	nation_building = {
+
+		icon = eng_propaganda_campaigns
+
+		days_remove = 120
+		
+		available = {
+			FROM = {
+				is_puppet_of = ROOT
+			}
+			FROM = {
+				democratic < 0.9
+			}
+			OR = {
+				political_power_daily > 0.5
+				has_political_power > 60
+			}
+		}
+
+		visible = {
+			has_government = democratic
+			FROM = {
+				is_puppet_of = ROOT
+				democratic < 0.99
+			}
+		}
+
+		target_array = subjects
+
+		target_trigger = {
+			FROM = {
+				is_puppet_of = ROOT
+			}
+		}
+
+		complete_effect = {
+			FROM = { add_timed_idea = { idea = nation_building days = 120 } }
+		}
+
+		modifier = {
+			political_power_cost = 0.5
+		}
+
+		ai_will_do = {
+			factor = 0
+		}
+	}
+	
+	socialist_education = {
+
+		icon = eng_propaganda_campaigns
+
+		days_remove = 120
+		
+		available = {
+			FROM = {
+				is_puppet_of = ROOT
+			}
+			FROM = {
+				communism < 0.9
+			}
+			OR = {
+				political_power_daily > 0.5
+				has_political_power > 60
+			}
+		}
+
+		visible = {
+			has_government = communism
+			NOT = {
+				AND = {
+					tag = ENG
+					has_completed_focus = ENG_concessions_to_the_trade_unions
+					FROM = {
+						OR = {
+							tag = CAN
+							tag = SAF
+							tag = RAJ
+							tag = AST
+							tag = NZL
+						}
+						has_government = communism
+					}
+				}
+			}
+			FROM = {
+				is_puppet_of = ROOT
+				communism < 0.99
+			}
+		}
+
+		target_array = subjects
+
+		target_trigger = {
+			FROM = {
+				is_puppet_of = ROOT
+			}
+		}
+
+		complete_effect = {
+			FROM = {
+				add_timed_idea = { idea = socialist_education days = 120 }
+			}
+		}
+		modifier = {
+			political_power_cost = 0.5
+		}
+
+		ai_will_do = {
+			factor = 0
+		}
+	}
+	
+	paramilitary_training = {
+
+		icon = eng_propaganda_campaigns
+
+		days_remove = 120
+		
+		available = {
+			FROM = {
+				is_puppet_of = ROOT
+			}
+			FROM = {
+				fascism < 0.9
+			}
+			OR = {
+				political_power_daily > 0.5
+				has_political_power > 60
+			}
+		}
+
+		visible = {
+			has_government = fascism
+			NOT = {
+				AND = {
+					tag = ENG
+					has_completed_focus = ENG_organize_the_blackshirts
+					FROM = {
+						OR = {
+							tag = CAN
+							tag = SAF
+							tag = RAJ
+							tag = AST
+							tag = NZL
+						}
+						has_government = fascism
+					}
+				}
+			}
+			FROM = {
+				is_puppet_of = ROOT
+				fascism < 0.99
+			}
+		}
+
+		target_array = subjects
+
+		target_trigger = {
+			FROM = {
+				is_puppet_of = ROOT
+			}
+		}
+
+		complete_effect = {
+			FROM = {
+				add_timed_idea = { idea = paramilitary_training days = 120 }
+			}
+		}
+
+		modifier = {
+			political_power_cost = 0.5
+		}
+
+		ai_will_do = {
+			factor = 0
+		}
+	}
+	
+	military_parade = {
+
+		icon = eng_propaganda_campaigns
+
+		days_remove = 120
+		
+		available = {
+			FROM = {
+				is_puppet_of = ROOT
+				neutrality < 0.9
+			}
+			OR = {
+				political_power_daily > 0.5
+				has_political_power > 60
+			}
+		}
+
+		visible = {
+			has_government = neutrality
+			FROM = {
+				is_puppet_of = ROOT
+				neutrality < 0.99
+			}
+		}
+
+		target_array = subjects
+
+		target_trigger = {
+			FROM = {
+				is_puppet_of = ROOT
+			}
+		}
+
+		complete_effect = {
+			FROM = {
+				add_timed_idea = { idea = military_parade days = 120 }
+			}
+		}
+
+		modifier = {
+			political_power_cost = 0.5
+		}
+
+		ai_will_do = {
+			factor = 0
+		}
+	}
+	
+	police_action = {
+
+		icon = generic_prepare_civil_war
+		
+		cost = 50
+		
+		available = {
+			FROM = {
+				is_puppet_of = ROOT
+			}
+			FROM = {
+				democratic > 0.6
+			}
+			FROM = {
+				NOT = { has_government = democratic }
+			}
+		}
+
+		visible = {
+			has_government = democratic
+			FROM = {
+				is_puppet_of = ROOT
+				NOT = { has_government = democratic }
+			}
+		}
+
+		target_array = subjects
+
+		target_trigger = {
+			FROM = {
+				is_puppet_of = ROOT
+			}
+		}
+
+		complete_effect = {
+			FROM = { country_event = { id = mtg_generic.1 } }
+			FROM = {
+				add_timed_idea = {
+					idea = political_turmoil
+					days = 365
+				}
+			}
+			FROM = {
+				set_politics = {
+					ruling_party = democratic
+					elections_allowed = yes
+				}
+			}
+		}
+		
+		ai_will_do = {
+			factor = 0
+		}
+	}
+	
+	fraternal_republic = {
+
+		icon = generic_prepare_civil_war
+		
+		cost = 50
+		
+		available = {
+			FROM = {
+				is_puppet_of = ROOT
+			}
+			FROM = {
+				communism > 0.6
+			}
+			FROM = {
+				NOT = { has_government = communism }
+			}
+		}
+
+		visible = {
+			has_government = communism
+			FROM = {
+				is_puppet_of = ROOT
+				NOT = { has_government = communism }
+			}
+			NOT = {
+				AND = {
+					tag = ENG
+					has_completed_focus = ENG_concessions_to_the_trade_unions
+					FROM = {
+						OR = {
+							tag = CAN
+							tag = SAF
+							tag = RAJ
+							tag = AST
+							tag = NZL
+						}
+					}
+				}
+			}
+		}
+
+		target_array = subjects
+
+		target_trigger = {
+			FROM = {
+				is_puppet_of = ROOT
+			}
+		}
+
+		complete_effect = {
+			FROM = { country_event = { id = mtg_generic.1 } }
+			FROM = {
+				add_timed_idea = {
+					idea = political_turmoil
+					days = 365
+				}
+			}
+			FROM = {
+				set_politics = {
+					ruling_party = communism
+					elections_allowed = no
+				}
+			}
+		}
+		
+		ai_will_do = {
+			factor = 0
+		}
+	}
+	
+	ultranationalist_coup = {
+
+		icon = generic_prepare_civil_war
+		
+		cost = 50
+		
+		available = {
+			FROM = {
+				is_puppet_of = ROOT
+			}
+			FROM = {
+				fascism > 0.6
+			}
+			FROM = {
+				NOT = { has_government = fascism }
+			}
+		}
+
+		visible = {
+			has_government = fascism
+			FROM = {
+				is_puppet_of = ROOT
+				NOT = { has_government = fascism }
+			}
+			NOT = {
+				AND = {
+					tag = ENG
+					has_completed_focus = ENG_organize_the_blackshirts
+					FROM = {
+						OR = {
+							tag = CAN
+							tag = SAF
+							tag = RAJ
+							tag = AST
+							tag = NZL
+						}
+					}
+				}
+			}
+		}
+
+		target_array = subjects
+
+		target_trigger = {
+			FROM = {
+				is_puppet_of = ROOT
+			}
+		}
+
+		complete_effect = {
+			FROM = { country_event = { id = mtg_generic.1 } }
+			FROM = {
+				add_timed_idea = {
+					idea = political_turmoil
+					days = 365
+				}
+			}
+			FROM = {
+				set_politics = {
+					ruling_party = fascism
+					elections_allowed = no
+				}
+			}
+		}
+		
+		ai_will_do = {
+			factor = 0
+		}
+	}
+	
+	military_dictatorship = {
+
+		icon = generic_prepare_civil_war
+		
+		cost = 50
+		
+		available = {
+			FROM = {
+				is_puppet_of = ROOT
+			}
+			FROM = {
+				neutrality > 0.6
+			}
+			FROM = {
+				NOT = { has_government = neutrality }
+			}
+		}
+
+		visible = {
+			has_government = neutrality
+			FROM = {
+				is_puppet_of = ROOT
+				NOT = { has_government = neutrality }
+			}
+		}
+
+		target_array = subjects
+
+		target_trigger = {
+			FROM = {
+				is_puppet_of = ROOT
+			}
+		}
+
+		complete_effect = {
+			FROM = { country_event = { id = mtg_generic.1 } }
+			FROM = {
+				add_timed_idea = {
+					idea = political_turmoil
+					days = 365
+				}
+			}
+			FROM = {
+				set_politics = {
+					ruling_party = neutrality
+					elections_allowed = no
+				}
+			}
+		}
+		
+		ai_will_do = {
+			factor = 0
+		}
+	}
+	
+	instantiate_collaboration = {
+		icon = generic_prepare_civil_war
+		
+		cost = 0
+
+		available = {
+			has_core_occupation_modifier = {
+				occupied_country_tag = FROM
+				modifier = compliance_80
+			}
+		}
+        visible = {
+			has_rule = can_create_collaboration_government
+			is_available_to_collaboration_government = yes
+			has_core_occupation_modifier = {
+				occupied_country_tag = FROM
+				modifier = compliance_60
+			}
+        }
+
+		complete_effect = {
+			set_temp_variable = { country_to_initiate = FROM }
+			instantiate_collaboration_government = yes
+		}
+
+		ai_will_do = {
+			factor = 0
+		}
+		
+		target_non_existing = yes
+		target_array = occupied_countries
+	}
+}

--- a/events/Embargo.txt
+++ b/events/Embargo.txt
@@ -1,0 +1,74 @@
+﻿###########################
+# Embargo Events
+###########################
+
+add_namespace = embargo
+
+# Embargo JAP
+country_event = {
+	id = embargo.1
+	title = embargo.1.t
+	desc = embargo.1.d
+	picture = GFX_report_event_generic_sign_treaty1
+	
+	is_triggered_only = yes
+	
+	option = {
+		name = embargo.1.a
+		ai_chance = { factor = 1 }
+		every_other_country = {
+			limit = {
+				OR = {
+					tag = JAP
+					is_in_faction_with = JAP
+				}
+			}
+			add_opinion_modifier = {
+				target = ROOT
+				modifier = embargo
+			}
+			reverse_add_opinion_modifier = {
+				target = ROOT
+				modifier = embargo
+			}
+		}
+	}
+	option = {
+		name = embargo.1.b
+		ai_chance = { factor = 0 }
+	}
+}
+
+country_event = {
+	id = embargo.2
+	title = embargo.2.t
+	desc = embargo.2.d
+	picture = GFX_report_event_generic_sign_treaty1
+	
+	is_triggered_only = yes
+	
+	option = {
+		name = embargo.2.a
+		ai_chance = { factor = 1 }
+		every_other_country = {
+			limit = {
+				OR = {
+					tag = GER
+					is_in_faction_with = GER
+				}
+			}
+			add_opinion_modifier = {
+				target = ROOT
+				modifier = embargo
+			}
+			reverse_add_opinion_modifier = {
+				target = ROOT
+				modifier = embargo
+			}
+		}
+	}
+	option = {
+		name = embargo.2.b
+		ai_chance = { factor = 0 }
+	}
+}

--- a/events/LAR_occupation.txt
+++ b/events/LAR_occupation.txt
@@ -1,0 +1,322 @@
+﻿
+add_namespace = occupied_countries
+
+#instantiate a collabration government
+country_event = {
+	id = occupied_countries.1
+	title = occupied_countries.1.title
+	desc = occupied_countries.1.desc
+	
+	# todo lar
+	picture = GFX_report_event_canadian_soldiers
+	
+	is_triggered_only = yes
+
+	option = {
+		name = occupied_countries.1.a
+
+		ai_chance = {
+			base = 0
+		}
+		
+		if = {
+			limit = {
+				has_core_occupation_modifier = {
+					occupied_country_tag = FROM.FROM
+					modifier = compliance_80
+				}
+				NOT = {
+					any_country_with_original_tag = { #copy of is_available_to_collaboration_government but from from scope because of events
+						original_tag_to_check = FROM.FROM
+						is_puppet_of = PREV # if already created one do not create another
+						has_autonomy_state = autonomy_collaboration_government
+					}
+				}
+			}
+			set_temp_variable = { country_to_initiate = FROM.FROM }
+			instantiate_collaboration_government = yes
+		}
+	}
+
+	option = {
+		name = occupied_countries.1.b
+		# do nothing
+		ai_chance = {
+			base = 100
+		}
+	}
+}
+
+
+# create uprising
+country_event = {
+	id = occupied_countries.2
+	
+	is_triggered_only = yes
+	
+	hidden = yes
+	
+	immediate = {
+		FROM = {
+			if = {
+				limit = {
+					has_core_occupation_modifier = {
+						occupied_country_tag = FROM
+						modifier = resistance_90
+					}
+				}
+				
+				set_temp_variable = { occupier_country = THIS }
+				set_temp_variable = { occupied_country = FROM }
+				set_temp_variable = { new_occupied_country = FROM }
+				
+				if = { #warsaw achievement
+					limit = {
+						var:occupied_country = { original_tag = POL }
+					}
+					set_global_flag = warsaw_liberated_self_flag
+				}
+				
+				
+				set_temp_variable = { civil_war_country_picked = 0 }
+				if = {
+					## pick an existing civil war country
+					limit = {
+						FROM = {
+							tag = PREV
+						}
+					}
+					
+					random_country_with_original_tag = {
+						original_tag_to_check = var:occupier_country
+						
+						limit = {
+							NOT = { tag = var:occupier_country }
+							has_war_with = var:occupier_country
+						}
+						
+						set_temp_variable = { civil_war_country_picked = 1 }
+						set_temp_variable = { new_occupied_country = this }
+					}
+				}
+				
+				if = {
+					## create a new country if necesarry
+					limit = {
+						check_variable = { civil_war_country_picked = 0 } 
+						FROM = {
+							#if resistance country exists and not at war with occupier (whitepaced/subjected etc) create a country instead
+							exists = yes
+							NOT = { has_war_with = occupier_country }
+						}
+					}
+					create_dynamic_country = {
+						original_tag = FROM
+						copy_tag = FROM
+						
+						set_temp_variable = { new_occupied_country = THIS }
+					}
+				}
+				
+				
+				# change ideology if necessary
+				if = {
+					limit = { 
+						var:occupied_country = {
+							#only change ideology if we are not creating a new country and old country is not existing
+							OR = {
+								exists = no
+								NOT = { tag = new_occupied_country }
+							}
+						}
+					}
+					
+					# booleans that will be allowed to change ideology
+					set_temp_variable = { allowed_party_neutrality = 1 }
+					set_temp_variable = { allowed_party_democratic = 1 }
+					set_temp_variable = { allowed_party_fascism = 1 }
+					set_temp_variable = { allowed_party_communism = 1 }
+					
+					# do not change ideology of occupier country
+					var:occupier_country = {
+						remove_from_allowed_party = yes
+					}
+					
+					if = {
+						# if occupied country exists and different than new country
+						# it is white peaced & subject of occupier. ignore its ideology as well
+						limit = { NOT = { check_variable = { new_occupied_country = occupied_country } } }
+						var:occupied_country = {
+							remove_from_allowed_party = yes
+						}
+					}
+					
+					# change government if necesarry
+					var:new_occupied_country = {
+						if = {
+							# check if our current ideology is OK
+							limit = { 
+								OR = {
+									AND = {
+										has_government = democratic
+										check_variable = { allowed_party_democratic = 0 }
+									}
+									AND = {
+										has_government = fascism
+										check_variable = { allowed_party_fascism = 0 }
+									}
+									AND = {
+										has_government = communism
+										check_variable = { allowed_party_communism = 0 }
+									}
+									AND = { 
+										has_government = neutrality
+										check_variable = { allowed_party_neutrality = 0 }
+									}
+								}
+							}
+							
+							random_list = {
+								allowed_party_democratic = {
+									set_popularities = {
+										democratic = 100
+									}
+									set_politics = { ruling_party = democratic elections_allowed = yes }
+								}
+								allowed_party_fascism = {
+									set_popularities = {
+										fascism = 100
+									}
+									set_politics = { ruling_party = fascism elections_allowed = no }
+								}
+								allowed_party_communism = {
+									set_popularities = {
+										communism = 100
+									}
+									set_politics = { ruling_party = communism elections_allowed = no }
+								}
+								allowed_party_neutrality = {
+									set_popularities = {
+										neutrality = 100
+									}
+									set_politics = { ruling_party = neutrality elections_allowed = no }
+								}
+							}
+						}
+					}
+				}
+				
+				# create resistance template for armies to spawn
+				var:new_occupied_country = {
+					if = {
+						limit = { NOT = { has_country_flag = created_civil_war_template } }
+						set_country_flag = created_civil_war_template
+							
+						division_template = {
+							name = "Resistance"
+							is_locked = yes
+							regiments = {
+								infantry = { x = 0 y = 0 }
+								infantry = { x = 0 y = 1 }
+					
+								infantry = { x = 1 y = 0 }
+								infantry = { x = 1 y = 1 }
+								
+								infantry = { x = 2 y = 0 }
+								infantry = { x = 2 y = 1 }
+							}
+						}
+					}
+				}
+				
+				
+				clear_temp_array = checked_neighbours
+				every_controlled_state = {
+					limit = { occupied_country_tag = occupied_country }
+					
+					# move our armies to back home
+					teleport_armies = {
+						limit = { 
+							OR = {
+								is_ally_with = occupier_country
+								has_military_access_to = occupier_country
+							}
+						}
+						to_state_array = owned_controlled_states
+					}
+					
+					# transfer state
+					if = {
+						limit = { has_resistance = yes }
+						set_resistance = 0
+					}
+					var:new_occupied_country = {
+						transfer_state = PREV
+					}
+					
+					if = {
+						limit = { 
+							var:occupier_country = {
+								check_variable = { resistance_already_inited@var:occupied_country = 0 } 
+							}
+						}
+						
+						# create resistance units, number is relative to size of industry
+						set_temp_variable = { num_units_to_create = building_level@arms_factory }
+						add_to_temp_variable = { num_units_to_create = building_level@industrial_complex } 
+						divide_temp_variable = { num_units_to_create = 3 }
+						add_to_temp_variable = { num_units_to_create = 2 }
+						round_temp_variable = num_units_to_create
+						clamp_temp_variable = { var = num_units_to_create min = 2 max = 6 }
+						for_loop_effect = {
+							end = num_units_to_create
+							
+							create_unit = {
+								division = "division_template = \"Resistance\" start_experience_factor = 1 start_equipment_factor = 1"
+								owner = new_occupied_country
+							}
+						}
+					}
+					
+					# also check neighbouring core states of the occupier that are not captured yet
+					# move our armies so they are not surrounded/create pockets
+					every_neighbor_state = {
+						limit = {
+							is_owned_and_controlled_by = occupied_country
+							is_core_of = occupied_country
+							not = { is_in_array = { checked_neighbours = this } }
+						}
+						add_to_temp_array = { checked_neighbours = this }
+						
+						teleport_armies = {
+							limit = { 
+								OR = {
+									is_ally_with = occupier_country
+									has_military_access_to = occupier_country
+								}
+							}
+							to_state_array = owned_controlled_states
+						}
+						
+						set_state_province_controller = {
+							controller = occupied_country
+							limit = {
+								is_ally_with = occupier_country
+							}
+						}
+					}
+				}
+			
+				# create war if necesarry
+				if = {
+					limit = { NOT = { has_war_with = new_occupied_country } }
+					declare_war_on = { target = new_occupied_country type = annex_everything }
+				}
+				
+				var:occupier_country = {
+					set_variable = { resistance_already_inited@var:occupied_country = 1 } 
+				}
+			
+			}
+		}
+	}

--- a/localisation/embargo_decisions_l_braz_por.yml
+++ b/localisation/embargo_decisions_l_braz_por.yml
@@ -1,0 +1,7 @@
+﻿l_braz_por:
+ USA_Embargo_JAP:0 "[USA.GetName] embargos all trade with [JAP.GetName]." 
+ Americas_Embargo_JAP:0 "[USA.GetName] asks all American Nations to follow it's Embargo on [JAP.GetName]."
+ ENG_Embargo_JAP:0 "[ENG.GetName] embargos any Trade with [JAP.GetName]."
+ Allies_Embargo_JAP:0 "[ENG.GetName] asks all its allies to follow it's Embargo on [JAP.GetName]."
+ USA_Embargo_GER:0 "[USA.GetName] embargos all trade with [GER.GetName]."
+ Americas_Embargo_GER:0 "[USA.GetName] asks all American Nations to follow it's Embargo on [GER.GetName]."

--- a/localisation/embargo_decisions_l_english.yml
+++ b/localisation/embargo_decisions_l_english.yml
@@ -1,0 +1,7 @@
+﻿l_english:
+ USA_Embargo_JAP:0 "[USA.GetName] embargos all trade with [JAP.GetName]." 
+ Americas_Embargo_JAP:0 "[USA.GetName] asks all American Nations to follow it's Embargo on [JAP.GetName]."
+ ENG_Embargo_JAP:0 "[ENG.GetName] embargos any Trade with [JAP.GetName]."
+ Allies_Embargo_JAP:0 "[ENG.GetName] asks all its allies to follow it's Embargo on [JAP.GetName]."
+ USA_Embargo_GER:0 "[USA.GetName] embargos all trade with [GER.GetName]."
+ Americas_Embargo_GER:0 "[USA.GetName] asks all American Nations to follow it's Embargo on [GER.GetName]."

--- a/localisation/embargo_decisions_l_french.yml
+++ b/localisation/embargo_decisions_l_french.yml
@@ -1,0 +1,7 @@
+﻿l_french:
+ USA_Embargo_JAP:0 "[USA.GetName] embargos all trade with [JAP.GetName]." 
+ Americas_Embargo_JAP:0 "[USA.GetName] asks all American Nations to follow it's Embargo on [JAP.GetName]."
+ ENG_Embargo_JAP:0 "[ENG.GetName] embargos any Trade with [JAP.GetName]."
+ Allies_Embargo_JAP:0 "[ENG.GetName] asks all its allies to follow it's Embargo on [JAP.GetName]."
+ USA_Embargo_GER:0 "[USA.GetName] embargos all trade with [GER.GetName]."
+ Americas_Embargo_GER:0 "[USA.GetName] asks all American Nations to follow it's Embargo on [GER.GetName]."

--- a/localisation/embargo_decisions_l_german.yml
+++ b/localisation/embargo_decisions_l_german.yml
@@ -1,0 +1,7 @@
+﻿l_german:
+ USA_Embargo_JAP:0 "[USA.GetName] startet ein Handelsembargo gegen [JAP.GetName]." 
+ Americas_Embargo_JAP:0 "[USA.GetName] fragt alle Amerikanische Nationen sich beim Embargo gegen [JAP.GetName] zu beteiligen."
+ ENG_Embargo_JAP:0 "[ENG.GetName] startet ein Handelsembargo gegen [JAP.GetName]."
+ Allies_Embargo_JAP:0 "[ENG.GetName] fragt alle seine allierten sich beim Embagro gegen [JAP.GetName] zu beteiligen."
+ USA_Embargo_GER:0 "[USA.GetName] startet ein Handelsembargo gegen [GER.GetName]."
+ Americas_Embargo_GER:0 "[USA.GetName] fragt alle Amerikanische Nationen sich beim Embargo gegen [GER.GetName] zu beteiligen."

--- a/localisation/embargo_decisions_l_polish.yml
+++ b/localisation/embargo_decisions_l_polish.yml
@@ -1,0 +1,7 @@
+﻿l_polish:
+ USA_Embargo_JAP:0 "[USA.GetName] embargos all trade with [JAP.GetName]." 
+ Americas_Embargo_JAP:0 "[USA.GetName] asks all American Nations to follow it's Embargo on [JAP.GetName]."
+ ENG_Embargo_JAP:0 "[ENG.GetName] embargos any Trade with [JAP.GetName]."
+ Allies_Embargo_JAP:0 "[ENG.GetName] asks all its allies to follow it's Embargo on [JAP.GetName]."
+ USA_Embargo_GER:0 "[USA.GetName] embargos all trade with [GER.GetName]."
+ Americas_Embargo_GER:0 "[USA.GetName] asks all American Nations to follow it's Embargo on [GER.GetName]."

--- a/localisation/embargo_decisions_l_russian.yml
+++ b/localisation/embargo_decisions_l_russian.yml
@@ -1,0 +1,7 @@
+﻿l_russian:
+ USA_Embargo_JAP:0 "[USA.GetName] embargos all trade with [JAP.GetName]." 
+ Americas_Embargo_JAP:0 "[USA.GetName] asks all American Nations to follow it's Embargo on [JAP.GetName]."
+ ENG_Embargo_JAP:0 "[ENG.GetName] embargos any Trade with [JAP.GetName]."
+ Allies_Embargo_JAP:0 "[ENG.GetName] asks all its allies to follow it's Embargo on [JAP.GetName]."
+ USA_Embargo_GER:0 "[USA.GetName] embargos all trade with [GER.GetName]."
+ Americas_Embargo_GER:0 "[USA.GetName] asks all American Nations to follow it's Embargo on [GER.GetName]."

--- a/localisation/embargo_decisions_l_spanish.yml
+++ b/localisation/embargo_decisions_l_spanish.yml
@@ -1,0 +1,7 @@
+﻿l_spanish:
+ USA_Embargo_JAP:0 "[USA.GetName] embargos all trade with [JAP.GetName]." 
+ Americas_Embargo_JAP:0 "[USA.GetName] asks all American Nations to follow it's Embargo on [JAP.GetName]."
+ ENG_Embargo_JAP:0 "[ENG.GetName] embargos any Trade with [JAP.GetName]."
+ Allies_Embargo_JAP:0 "[ENG.GetName] asks all its allies to follow it's Embargo on [JAP.GetName]."
+ USA_Embargo_GER:0 "[USA.GetName] embargos all trade with [GER.GetName]."
+ Americas_Embargo_GER:0 "[USA.GetName] asks all American Nations to follow it's Embargo on [GER.GetName]."

--- a/localisation/embargo_events_l_braz_por.yml
+++ b/localisation/embargo_events_l_braz_por.yml
@@ -1,0 +1,9 @@
+﻿l_braz_por:
+ embargo.1.t:0 "Embargo against the [JAP.GetFactionName]"
+ embargo.1.d:0 "We got asked to join an Embargo against the [JAP.GetFactionName]."
+ embargo.1.a:0 "We will stop trading with them aswell."
+ embargo.1.b:0 "We won't limit our Trade."
+ embargo.2.t:0 "Embargo against the [GER.GetFactionName]"
+ embargo.2.d:0 "We got asked to join an Embargo against [GER.GetFactionName]."
+ embargo.2.a:0 "We will stop trading with them aswell."
+ embargo.2.b:0 "We won't limit our Trade."

--- a/localisation/embargo_events_l_english.yml
+++ b/localisation/embargo_events_l_english.yml
@@ -1,0 +1,9 @@
+﻿l_english:
+ embargo.1.t:0 "Embargo against the [JAP.GetFactionName]"
+ embargo.1.d:0 "We got asked to join an Embargo against the [JAP.GetFactionName]."
+ embargo.1.a:0 "We will stop trading with them aswell."
+ embargo.1.b:0 "We won't limit our Trade."
+ embargo.2.t:0 "Embargo against the [GER.GetFactionName]"
+ embargo.2.d:0 "We got asked to join an Embargo against [GER.GetFactionName]."
+ embargo.2.a:0 "We will stop trading with them aswell."
+ embargo.2.b:0 "We won't limit our Trade."

--- a/localisation/embargo_events_l_french.yml
+++ b/localisation/embargo_events_l_french.yml
@@ -1,0 +1,9 @@
+﻿l_french:
+ embargo.1.t:0 "Embargo against the [JAP.GetFactionName]"
+ embargo.1.d:0 "We got asked to join an Embargo against the [JAP.GetFactionName]."
+ embargo.1.a:0 "We will stop trading with them aswell."
+ embargo.1.b:0 "We won't limit our Trade."
+ embargo.2.t:0 "Embargo against the [GER.GetFactionName]"
+ embargo.2.d:0 "We got asked to join an Embargo against [GER.GetFactionName]."
+ embargo.2.a:0 "We will stop trading with them aswell."
+ embargo.2.b:0 "We won't limit our Trade."

--- a/localisation/embargo_events_l_german.yml
+++ b/localisation/embargo_events_l_german.yml
@@ -1,0 +1,9 @@
+﻿l_german:
+ embargo.1.t:0 "Embargo gegen die [JAP.GetFactionName]"
+ embargo.1.d:0 "Wir wurden angefragt uns bei einem Handelsembargo gegen die [JAP.GetFactionName] zu beteiligen."
+ embargo.1.a:0 "Wir hören auch auf mit ihnen zu handeln."
+ embargo.1.b:0 "Wir handeln mit jedem."
+ embargo.2.t:0 "Embargo gegen die [GER.GetFactionName]"
+ embargo.2.d:0 "Wir wurden angefragt uns bei einem Handelsembargo gegen die [GER.GetFactionName] zu beteiligen."
+ embargo.2.a:0 "Wir hören auch auf mit ihnen zu handeln."
+ embargo.2.b:0 "Wir handeln mit jedem."

--- a/localisation/embargo_events_l_polish.yml
+++ b/localisation/embargo_events_l_polish.yml
@@ -1,0 +1,9 @@
+﻿l_polish:
+ embargo.1.t:0 "Embargo against the [JAP.GetFactionName]"
+ embargo.1.d:0 "We got asked to join an Embargo against the [JAP.GetFactionName]."
+ embargo.1.a:0 "We will stop trading with them aswell."
+ embargo.1.b:0 "We won't limit our Trade."
+ embargo.2.t:0 "Embargo against the [GER.GetFactionName]"
+ embargo.2.d:0 "We got asked to join an Embargo against [GER.GetFactionName]."
+ embargo.2.a:0 "We will stop trading with them aswell."
+ embargo.2.b:0 "We won't limit our Trade."

--- a/localisation/embargo_events_l_russian.yml
+++ b/localisation/embargo_events_l_russian.yml
@@ -1,0 +1,9 @@
+﻿l_russian:
+ embargo.1.t:0 "Embargo against the [JAP.GetFactionName]"
+ embargo.1.d:0 "We got asked to join an Embargo against the [JAP.GetFactionName]."
+ embargo.1.a:0 "We will stop trading with them aswell."
+ embargo.1.b:0 "We won't limit our Trade."
+ embargo.2.t:0 "Embargo against the [GER.GetFactionName]"
+ embargo.2.d:0 "We got asked to join an Embargo against [GER.GetFactionName]."
+ embargo.2.a:0 "We will stop trading with them aswell."
+ embargo.2.b:0 "We won't limit our Trade."

--- a/localisation/embargo_events_l_spanish.yml
+++ b/localisation/embargo_events_l_spanish.yml
@@ -1,0 +1,9 @@
+﻿l_spanish:
+ embargo.1.t:0 "Embargo against the [JAP.GetFactionName]"
+ embargo.1.d:0 "We got asked to join an Embargo against the [JAP.GetFactionName]."
+ embargo.1.a:0 "We will stop trading with them aswell."
+ embargo.1.b:0 "We won't limit our Trade."
+ embargo.2.t:0 "Embargo against the [GER.GetFactionName]"
+ embargo.2.d:0 "We got asked to join an Embargo against [GER.GetFactionName]."
+ embargo.2.a:0 "We will stop trading with them aswell."
+ embargo.2.b:0 "We won't limit our Trade."


### PR DESCRIPTION
Added decisions for USA to embargo JAP and GER and their factions, locked behind conditions (GER war with ENG, JAP Secure_China Focus) and costing 75 PP.
Another decision to send events too all of American Nations to also embargo GER/JAP, costing 75 PP each.

Added decision for UK to Embargo JAP, same conditions as above. Also decision to ask its Allies to embargo JAP aswell.

Added localisation for those.

Embargo maybe needs buff from -100 to -1000 strength, right now the Axis/Japan still can trade marginal amounts of ressources.

To test:
Start as Germany, allowdiplo, declare war on ENG, tag to USA, pp 150, take decisions, tag to MEX or other american nation, progess ~3 days, event should plop to ask to join embagro (ai will always say yes.)