### PR TITLE
Voigit ai scripts

### DIFF
--- a/common/ai_strategy_plans/ALB_MP_plan.txt
+++ b/common/ai_strategy_plans/ALB_MP_plan.txt
@@ -1,0 +1,59 @@
+ALB_MP_1 = {
+	name = "Albanian Multiplayer 1"
+	desc = ""
+
+	enable = {
+		original_tag = ALB
+		has_game_rule = {
+			rule = ALB_ai_behavior
+			option = ALB_MP_1
+			}
+	}
+
+	abort = {
+	}
+
+	ai_national_focuses = {
+		industrial_effort
+		production_effort
+		production_effort_2
+		production_effort_3
+		construction_effort
+		construction_effort_2
+		infrastructure_effort
+		construction_effort_3
+		naval_effort
+		infrastructure_effort_2
+		extra_tech_slot
+	}
+
+	research = {
+		infantry_weapons = 100
+		land_doctrine = -1000
+		air_doctrine = -1000
+		naval_doctrine = -1000
+	}
+
+	ideas = {
+		ALB_midhat_frasheri = 1000
+	}
+
+	ai_strategy = {
+	}	
+
+	traits = {
+	}
+
+	# Keep small, as it is used as a factor for some things (such as research needs)
+	# Recommended around 1.0. Useful for relation between plans
+	weight = {
+		factor = 1.0
+		modifier = {
+			factor = 1.0
+		}
+	}
+
+	focus_factors = {
+	}
+
+}

--- a/common/ai_strategy_plans/AST_MP_plan.txt
+++ b/common/ai_strategy_plans/AST_MP_plan.txt
@@ -1,0 +1,219 @@
+AST_MP_1 = {
+	name = "Australian Multiplayer Plan 1"
+	desc = ""
+
+	enable = {
+		original_tag = AST
+		has_dlc = "Together for Victory"
+		has_game_rule = {
+			rule = AST_ai_behavior
+			option = AST_MP_1
+		}
+	}
+	
+	abort = {
+	}
+
+	ai_national_focuses = {
+		AST_establish_advisory_war_council
+		AST_national_security_act
+		AST_army_inventions_directorate
+		AST_civil_construction_corps
+		AST_invest_in_victory
+		AST_squash_the_squanderbugs
+		AST_fight_work_or_perish
+		AST_support_the_policy_of_appeasement
+		AST_strengthen_ties_with_uk
+		AST_adopt_westminster
+		AST_CSIR
+		AST_commonwealth_aircraft_corporation
+		AST_volunteer_defence_corps
+		AST_citizen_military_forces
+		AST_standard_gauge_railway
+		AST_industries_assistance_corporation
+		AST_western_australian_government_railways
+		AST_south_australian_housing_trust
+		AST_department_of_supply_and_development
+		AST_allied_works_council
+		AST_expand_lithgow_small_arms_factory
+		AST_expand_the_raaf
+		AST_cac_boomerang
+		AST_additional_militia_training
+		AST_royal_australian_artillery
+		AST_daimler_dingo
+		AST_sentinel_tank_project
+		AST_promote_reservists
+		AST_hmas_assault
+		AST_australian_womens_army_service
+		AST_swpa_protector
+		AST_expand_the_northern_railway
+		AST_specialize_equipment
+		AST_fund_owen_gun_research
+		AST_volunteer_air_observers_corps
+		AST_womens_auxilliary_australian_air_force
+		AST_cockatoo_island_shipyards
+		AST_protect_overseas_commerce
+		AST_expand_northern_presence
+		AST_empire_air_training_scheme
+		AST_royal_australian_submarine_service
+		AST_airborne_defence
+		AST_introduce_unconventional_warfare
+		AST_death_from_down_under
+		AST_dominate_the_skies
+		AST_rationing_and_recycling
+		AST_classify_aliens
+		AST_fund_australian_defense_research
+		AST_australian_arms_production
+		AST_research_collaboration
+	}
+	
+	focus_factors = {
+	}
+
+	research = {
+		cat_mobile_warfare = 10
+		cat_superior_firepower = -10000
+		cat_grand_battle_plan = -10000
+		cat_mass_assault = -10000
+	}
+
+	ideas = {
+	AST_herbert_v_evatt = 1000
+	partial_economic_mobilisation = 100000
+	bhp_steel = 10
+	free_trade = 10000
+	}
+
+	traits = {
+		captain_of_industry = 5
+		war_industrialist = 5
+	}
+
+	# Keep small, as it is used as a factor for some things (such as research needs)
+	# Recommended around 1.0. Useful for relation between plans
+	weight = {
+		factor = 1.0
+		modifier = {
+			factor = 1.0
+		}
+	}
+
+	focus_factors = {
+		
+	}
+
+}
+
+AST_MP_Electronics_1 = {
+	name = "Australian Multiplayer Plan Electronics 1"
+	desc = ""
+
+	enable = {
+		original_tag = AST
+		has_game_rule = {
+			rule = AST_ai_behavior
+			option = AST_MP_1
+		}
+		NOT = { has_tech = electronic_mechanical_engineering }
+	}
+	
+	abort = {
+		has_tech = electronic_mechanical_engineering 
+	}
+
+	research = {
+		electronics = 10000
+		industry = -5000
+	}
+}
+
+AST_MP_Electronics_2 = {
+	name = "Australian Multiplayer Plan Electronics 2"
+	desc = ""
+
+	enable = {
+		original_tag = AST
+		OR = {
+			has_game_rule = {
+				rule = AST_ai_behavior
+				option = AST_MP_1
+			}
+			has_game_rule = {
+				rule = AST_ai_behavior
+				option = AST_MP_2
+			}
+		}
+		NOT = { has_tech = mechanical_computing }
+	}
+	
+	abort = {
+		has_tech = mechanical_computing 
+	}
+
+	research = {
+		computing_tech = 100000
+		industry = -5000
+	}
+}
+
+
+AST_MP_1_NoCAS = {
+	name = "Australian Mulitplayer Plan 1"
+	desc = ""
+
+	enable = {
+		original_tag = AST
+		has_game_rule = {
+			rule = AST_ai_behavior
+			option = AST_MP_1
+		}
+
+	}
+
+	abort = {
+	}
+	
+	ai_strategy = {
+		type = equipment_production_factor
+		id = cas
+		value = -10000
+	}
+	ai_strategy = {
+		type = equipment_production_factor
+		id = naval_bomber
+		value = -10000
+	}
+	ai_strategy = {
+		type = equipment_production_factor
+		id = tactical_bomber
+		value = -100000
+	}
+	ai_strategy = {
+		type = equipment_production_factor
+		id = strategic_bomber
+		value = -10000
+	}
+}
+
+
+AST_MP_1_NoShips = {
+	name = "Australian Mulitplayer Plan NoShips"
+	desc = ""
+
+	enable = {
+		original_tag = AST
+		has_game_rule = {
+			rule = AST_ai_behavior
+			option = AST_MP_1
+		}
+	}
+
+	abort = {
+	}
+	
+	ai_strategy = {
+		type = equipment_production_factor
+		id = screen_ship
+		value = -10000
+	}
+}

--- a/common/ai_strategy_plans/BUL_MP_plan.txt
+++ b/common/ai_strategy_plans/BUL_MP_plan.txt
@@ -1,0 +1,112 @@
+BUL_MP_1 = {
+	name = "Bulgarian Multiplayer 1"
+	desc = ""
+
+	enable = {
+		original_tag = BUL
+		has_game_rule = {
+			rule = BUL_ai_behavior
+			option = BUL_MP_1
+		}
+	}
+
+	abort = {
+	}
+
+	ai_national_focuses = {
+		industrial_effort
+		construction_effort
+		construction_effort_2
+		production_effort
+		production_effort_2
+		production_effort_3
+		infrastructure_effort
+		infrastructure_effort_2
+		extra_tech_slot
+		extra_tech_slot_2
+		construction_effort_3
+		naval_effort
+		political_effort
+		collectivist_ethos
+		nationalism_focus
+		militarism
+		military_youth
+		paramilitarism
+		ideological_fanaticism
+		technology_sharing
+		army_effort
+		motorization_effort
+		mechanization_effort
+		armor_effort
+		aviation_effort
+	}
+
+	research = {
+		synth_resources = -1000
+		excavation_tech = -200
+		air_doctrine = -10000
+		naval_doctrine = -10000
+		cat_mobile_warfare = -1000
+		cat_superior_firepower = -1000
+		cat_grand_battle_plan = -1000
+	}
+
+	ideas = {
+		free_trade = 100000
+		export_focus = 0
+		BUL_dobri_bozhilov = 10
+		war_economy = 20
+		partial_economic_mobilisation = 10
+		extensive_conscription = 10
+		generic_industrial_concern = 5
+		BUL_konstantin_muraviev = 0
+		BUL_georgi_ivanov_kyoseivanov = 0
+	}
+	
+		
+	ai_strategy = {
+	}
+
+	traits = {
+	}
+
+	# Keep small, as it is used as a factor for some things (such as research needs)
+	# Recommended around 1.0. Useful for relation between plans
+	weight = {
+		factor = 1.0
+		modifier = {
+			factor = 1.0
+		}
+	}
+
+	focus_factors = {
+		CAS_effort = 0
+		rocket_effort = 0
+		large_navy = 0
+		flexible_navy = 0
+		nuclear_effort = 0
+	}
+}
+
+
+BUL_MP_Electronics_1 = {
+	name = "Bulgarian Multiplayer Plan Electronics 2"
+	desc = ""
+
+	enable = {
+		original_tag = BUL
+		has_game_rule = {
+			rule = BUL_ai_behavior
+			option = BUL_MP_1
+		}
+		NOT = { has_tech = mechanical_computing }
+	}
+	
+	abort = {
+		has_tech = mechanical_computing 
+	}
+
+	research = {
+		computing_tech = 100000
+	}
+}

--- a/common/ai_strategy_plans/CAN_MP_plan.txt
+++ b/common/ai_strategy_plans/CAN_MP_plan.txt
@@ -1,0 +1,435 @@
+CAN_MP_1 = {
+	name = "Canada MP Plan 1"
+	desc = ""
+
+	enable = {
+		original_tag = CAN
+			has_game_rule = {
+				rule = CAN_ai_behavior
+				option = CAN_MP_1
+				}
+			}
+
+	abort = {
+	}
+
+	ai_national_focuses = {
+		CAN_rowell_sirois_commission
+		CAN_rcaf_station_borden
+		CAN_we_have_the_hurricane
+		CAN_defence_of_canada_regulations
+		CAN_wartime_prices_and_trade_board
+		CAN_canada_wheat_board
+		CAN_national_resources_mobilization_act
+		CAN_fund_the_national_research_council
+		CAN_commit_to_the_war
+		CAN_war_bonds
+		CAN_crown_corporations
+		CAN_national_housing_act
+		CAN_strengthen_the_commonwealth_ties
+		CAN_shadow_factories
+		CAN_montreal_laboratory_collaboration
+		CAN_department_of_munitions_and_supply
+		CAN_victory_aircraft_limited
+		CAN_bits_and_pieces_program
+		CAN_john_inglis_and_company
+		CAN_if_day
+		CAN_mine_the_shield
+		CAN_alberta_coal_towns
+		CAN_national_steel_car
+		CAN_war_fueled_economy
+		CAN_halifax_shipyards
+		CAN_canada_pacific_railway
+		CAN_the_plan
+		CAN_camp_x
+		CAN_supply_the_empire
+		CAN_aluminium_company_of_canada
+		CAN_turner_valley_oilfield
+		CAN_army_modernization
+		CAN_cmp_truck
+		CAN_a_motorized_army
+		CAN_red_deer_training_camp
+		CAN_the_valentine_tank
+		CAN_canadian_infantry_corps
+		CAN_dollar_a_year_men
+		CAN_royal_regiment_of_canadian_artillery
+		CAN_retool_angus_shops	
+		CAN_imperial_oil
+		CAN_light_cruiser_effort
+		CAN_escort_fleet
+		CAN_trade_fleet
+		CAN_degauss_ship_hulls
+		CAN_united_shipyards		
+		#CAN_habakkuk_carrier
+		CAN_maritime_colonial_railway
+		
+		
+		
+	}
+
+	research = {
+		cat_battlefield_support = -1000
+		cat_operational_integrity = -1000
+		cat_superior_firepower = -1000
+		cat_grand_battle_plan = -1000
+		cat_mass_assault = -1000
+	}
+
+	ideas = {
+		civilian_economy = 0
+		CAN_r_b_bennett = 1000
+		CAN_harry_crerar = 100
+		canadian_car_foundry = 100
+		free_trade = 10000
+		export_focus = 0
+	}
+
+	traits = {
+		captain_of_industry = 5
+		war_industrialist = 5
+	}
+
+	# Keep small, as it is used as a factor for some things (such as research needs)
+	# Recommended around 1.0. Useful for relation between plans
+	weight = {
+		factor = 1.0
+		modifier = {
+			factor = 1.0
+		}
+	}
+
+	focus_factors = {
+		
+	}
+
+}
+
+CAN_MP_Buildup = {
+	name = ""
+	desc = ""
+
+	enable = {
+		tag = CAN
+		has_game_rule = {
+			rule = CAN_ai_behavior
+			option = CAN_MP_1
+		}
+		date < 1938.1.1
+	}
+
+	abort = {
+		date > 1938.1.1 
+	}
+
+	ai_strategy = {
+		type = building_target
+		id = industrial_complex
+		target = 276
+		value = 10
+	}
+}
+
+CAN_MP_AirDoctrine = {
+	name = "Air Doctrine Research"
+	desc = ""
+
+	enable = {
+		original_tag = CAN
+		has_game_rule = {
+			rule = CAN_ai_behavior
+			option = CAN_MP_1
+		}
+	has_tech = logistical_bombing
+	}
+	abort = { 
+	}
+	
+	research = {
+		cat_strategic_destruction = -1000
+	}
+}
+
+CAN_MP_1_LessInfProd = {
+	name = "Fighter Production"
+	desc = ""
+
+	enable = {
+		original_tag = CAN
+		has_game_rule = {
+			rule = CAN_ai_behavior
+			option = CAN_MP_1
+		}
+		has_tech = fighter1
+	}
+	abort = {
+	}
+	
+	ai_strategy = {
+		type = equipment_production_factor
+		id = infantry
+		value = -1000
+	
+	}
+}
+
+CAN_MP_1_NoScreen = {
+	name = "Fighter Production"
+	desc = ""
+
+	enable = {
+		original_tag = CAN
+		has_game_rule = {
+			rule = CAN_ai_behavior
+			option = CAN_MP_1
+		}
+	}
+	abort = {
+	}
+	
+	ai_strategy = {
+		type = equipment_production_factor
+		id = screen_ship
+		value = -100
+	
+	}
+}
+
+CAN_MP_1_Fighter_prod = {
+	name = "Fighter Production"
+	desc = ""
+
+	enable = {
+		original_tag = CAN
+		has_game_rule = {
+			rule = CAN_ai_behavior
+			option = CAN_MP_1
+		}
+		has_tech = fighter1
+	}
+	abort = {
+	}
+	
+	ai_strategy = {
+		type = air_factory_balance
+		value = 1000
+	}
+	ai_strategy = {
+		type = equipment_variant_production_factor
+		id = fighter_equipment
+		value = 100
+	}
+}
+
+CAN_MP_1_NoCAS = {
+	name = "No CAS Production"
+	desc = ""
+
+	enable = {
+		original_tag = CAN
+		has_game_rule = {
+			rule = CAN_ai_behavior
+			option = CAN_MP_1
+		}
+	}
+	abort = {
+	}
+	
+	ai_strategy = {
+		type = equipment_production_factor
+		id = cas
+		value = -10000
+	}
+	ai_strategy = {
+		type = equipment_production_factor
+		id = naval_bomber
+		value = -10000
+	}
+	ai_strategy = {
+		type = equipment_production_factor
+		id = tactical_bomber
+		value = -10000
+	}
+	ai_strategy = {
+		type = equipment_production_factor
+		id = strategic_bomber
+		value = -10000
+	}
+}
+
+CAN_MP_Fighter1 = {
+	name = "Research Fighter"
+	desc = ""
+
+	enable = {
+		original_tag = CAN
+		has_game_rule = {
+			rule = CAN_ai_behavior
+			option = CAN_MP_1
+		}
+		NOT = { has_tech = fighter1 }
+	}
+
+	abort = {
+		has_tech = fighter1
+	}
+
+	research = {
+		light_fighter = 10000
+	}
+
+}
+
+CAN_MP_Fighter2 = {
+	name = "Research Fighter"
+	desc = ""
+
+	enable = {
+		original_tag = CAN
+		has_game_rule = {
+			rule = CAN_ai_behavior
+			option = CAN_MP_1
+		}
+		has_completed_focus = CAN_we_have_the_hurricane
+		NOT = { has_tech = fighter2 }
+	}
+
+	abort = {
+		has_tech = fighter2
+	}
+
+	research = {
+		light_fighter = 10000
+	}
+
+}
+
+CAN_MP_Fighter3 = {
+	name = "Research Fighter"
+	desc = ""
+
+	enable = {
+		original_tag = CAN
+		has_game_rule = {
+			rule = CAN_ai_behavior
+			option = CAN_MP_1
+		}
+		has_tech = fighter2
+		NOT = { has_tech = fighter3 }
+	}
+
+	abort = {
+		has_tech = fighter3
+	}
+
+	research = {
+		light_fighter = 1000
+	}
+
+}
+
+No_PP_For_Relation = {
+	name = ""
+	desc = ""
+
+	enable = {
+		original_tag = CAN
+		has_game_rule = {
+			rule = CAN_ai_behavior
+			option = CAN_MP_1
+		}
+	}
+
+	abort = {
+	}
+
+	ai_strategy = {
+		type = pp_spend_priority
+		id = relation	
+		value = -200
+	}	
+}
+
+CAN_MP_No_Generals = {
+	name = ""
+	desc = ""
+
+	enable = {
+		tag = RAJ
+		has_game_rule = {
+			rule = RAJ_ai_behavior
+			option = RAJ_MP_1
+		}
+		date < 1939.1.1
+	}
+
+	abort = {
+		date > 1939.1.1
+	}
+
+	ai_strategy = {
+		type = pp_spend_priority
+		id = general
+		value = -1000
+	}
+	ai_strategy = {
+		type = pp_spend_priority
+		id = admiral
+		value = -1000
+	}
+}
+
+CAN_MP_UK_Support = {
+	name = "Befriend UK to accept every request from them"
+	desc = ""
+
+	enable = {
+		original_tag = CAN
+		has_game_rule = {
+			rule = CAN_ai_behavior
+			option = CAN_MP_1
+		}
+	}
+
+	abort = {
+	}
+
+	ai_strategy = {
+		type = befriend
+		id = ENG
+		value = 200
+	}
+	ai_strategy = {
+		type = support
+		id = ENG
+		value = 1000
+	}
+
+}
+
+CAN_MP_USA_Support = {
+	name = "Support USA to accept every request from them"
+	desc = ""
+
+	enable = {
+		original_tag = CAN
+		has_game_rule = {
+			rule = CAN_ai_behavior
+			option = CAN_MP_1
+		}
+	}
+
+	abort = {
+	}
+
+	ai_strategy = {
+		type = befriend
+		id = USA
+		value = 200
+	}
+	ai_strategy = {
+		type = support
+		id = USA
+		value = 200
+	}
+
+}

--- a/common/ai_strategy_plans/CHI_MP_plan.txt
+++ b/common/ai_strategy_plans/CHI_MP_plan.txt
@@ -1,0 +1,431 @@
+CHI_MP_1_Fight = {
+	name = "Nationalist China Multiplayer Plan 1"
+	desc = "Fight against Japan"
+
+	enable = {
+		original_tag = CHI
+		is_subject = no
+		has_game_rule = {
+			rule = CHI_ai_behavior
+			option = CHI_MP_1
+		}
+	}
+
+	abort = {
+		CHI = {
+			is_subject = yes
+		}
+	}
+
+
+	ai_national_focuses = {
+		CHI_unified_industrial_planning
+		CHI_expand_the_academica_sinica
+		CHI_three_principles_of_the_people
+		CHI_democracy
+		CHI_executive_yuan
+		CHI_nationalism
+		CHI_foreign_threats
+		CHI_united_front
+		CHI_military_affairs_commission
+		CHI_army_reform
+		CHI_war_of_resistance
+		CHI_war_of_national_liberation
+		CHI_war_of_anti_imperialism
+		CHI_invite_foreign_investors
+		CHI_reach_out_to_france
+		CHI_guarantee_the_hanoi_route
+		CHI_mission_to_the_soviet_union
+		CHI_invite_soviet_advisers 
+		CHI_the_soviet_volunteer_group
+		CHI_rural_reconstruction_movement
+		CHI_mining_commission
+		CHI_develop_the_hanyan_arsenal
+		CHI_financial_policy
+		CHI_price_controls
+		CHI_reform_the_national_bank
+		CHI_forced_loans
+		CHI_mission_to_the_us
+		CHI_french_military_mission
+		CHI_french_drill
+		CHI_rapprochement_with_soviet_union
+		CHI_purchase_tanks
+		CHI_experimental_mechanised_unit
+		CHI_scorched_earth_tactics
+		CHI_welfare
+		CHI_forced_conscription
+		CHI_refugee_relief_agency
+		CHI_land_tax_reform
+		CHI_new_life_movement
+		CHI_modern_logistics
+		CHI_renegotiate_the_unequal_treaties
+		CHI_one_china_policy
+		CHI_integrate_tibet
+	}
+
+	research = {
+		cat_mass_assault = 10
+		infantry_weapons = 5
+		industry = 5
+		air_doctrine = -1000
+	}
+
+	ideas = {
+		CHI_chiang_ching_kuo = 50
+		CHI_soong_mei_ling = 10
+		civilian_economy = 0
+		low_economic_mobilisation = 100
+		partial_economic_mobilisation = 200
+		war_economy = 300
+		free_trade = 20000
+		CHI_h_h_kung = 0
+		CHI_chen_yi = 0
+		CHI_kwong_jiang = 0
+		CHI_dai_li = 0
+		CHI_chen_guofu = 0
+		CHI_gao_zhihang = 0
+		CHI_fang_zeyi = 0
+		CHI_huang_shen = 0
+	}
+	
+	ai_strategy = {
+		type = prepare_for_war
+		id = JAP
+		value = 200
+	}
+
+	# Keep small, as it is used as a factor for some things (such as research needs)
+	# Recommended around 1.0. Useful for relation between plans
+	weight = {
+		factor = 1.0
+		modifier = {
+			factor = 1.0
+		}
+	}
+
+}
+
+CHI_MP_1_Alliance = {
+	name = "Ally Warlords"
+	desc = ""
+
+	enable = {
+		original_tag = CHI
+		has_game_rule = {
+			rule = CHI_ai_behavior
+			option = CHI_MP_1
+		}
+		CHI = {
+			is_subject = no
+		}
+	}
+
+	abort = {
+		CHI = {
+			is_subject = yes
+		}
+	}
+
+	ai_strategy = {
+		type = alliance
+		id = PRC
+		value = 200
+	}
+	ai_strategy = {
+		type = alliance
+		id = SHX
+		value = 200
+	}
+	ai_strategy = {
+		type = alliance
+		id = XSM
+		value = 200
+	}
+	ai_strategy = {
+		type = alliance
+		id = SIK
+		value = 200
+	}
+	ai_strategy = {
+		type = alliance
+		id = YUN
+		value = 200
+	}
+	ai_strategy = {
+		type = alliance
+		id = GXC
+		value = 200
+	}
+}
+
+CHI_MP_Only_Befriend_Helpers_for_Focus = {
+	name = "Befriend Helpers"
+	desc = ""
+
+	enable = {
+		original_tag = CHI
+		has_game_rule = {
+			rule = CHI_ai_behavior
+			option = CHI_MP_1
+		}
+	}
+
+	abort = {
+		OR = {
+			focus_progress = {
+				focus = CHI_invite_foreign_investors
+				progress > 0.1
+			}
+			AND = { 
+				has_completed_focus = CHI_invite_foreign_investors
+				NOT = { has_completed_focus = CHI_the_soviet_volunteer_group }
+			}
+		}
+	}
+
+	ai_strategy = {
+		type = pp_spend_priority
+		id = relation	
+		value = -200
+	}	
+}
+
+CHI_MP_Befriend_FRA = {
+	name = "Befriend FRA"
+	desc = ""
+
+	enable = {
+		original_tag = CHI
+		has_game_rule = {
+			rule = CHI_ai_behavior
+			option = CHI_MP_1
+		}
+		OR = {
+			focus_progress = {
+				focus = CHI_invite_foreign_investors
+				progress > 0.1
+			}
+			AND = { 
+				has_completed_focus = CHI_invite_foreign_investors
+				NOT = { has_completed_focus = CHI_guarantee_the_hanoi_route }
+			}
+		}
+	}
+
+	abort = {
+		has_completed_focus = CHI_guarantee_the_hanoi_route
+	}
+
+	ai_strategy = {
+		type = befriend
+		id = FRA
+		value = 200
+	}	
+}
+
+CHI_MP_Befriend_SOV = {
+	name = "Befriend SOV"
+	desc = ""
+
+	enable = {
+		original_tag = CHI
+		has_game_rule = {
+			rule = CHI_ai_behavior
+			option = CHI_MP_1
+		}
+		OR = {
+			focus_progress = {
+				focus = CHI_guarantee_the_hanoi_route
+				progress > 0.1
+			}
+			AND = { 
+				has_completed_focus = CHI_guarantee_the_hanoi_route
+				NOT = { has_completed_focus = CHI_the_soviet_volunteer_group }
+			}
+		}
+	}
+
+	abort = {
+		has_completed_focus = CHI_the_soviet_volunteer_group
+	}
+
+	ai_strategy = {
+		type = befriend
+		id = SOV
+		value = 200
+	}	
+}
+
+MP_Early_PP = {
+	name = "Early PP Spending"
+	desc = ""
+
+	enable = {
+		original_tag = CHI
+		has_game_rule = {
+			rule = CHI_ai_behavior
+			option = CHI_MP_1
+		}
+		date < 1940.1.1
+	}
+
+	abort = {
+		date > 1940.1.1
+	}
+
+	ideas = {
+		CHI_xiao_jinguang = 0
+		CHI_bai_chongxi = 0
+		CHI_chen_shaokuan = 0
+		CHI_wang_shuming = 0
+		SIA_thawon_thamrongnawasawat = 0
+		SIA_tianliang_huntrakool = 0
+		SIA_sindhu_kamalanavin = 0
+		SIA_luang_sinthusongkhramchai = 0
+		SIA_phraya_thayarnpikart = 0
+		SIA_pridi_phanomyong = 0
+		SIA_phraya_preechacholayudha = 0
+		tank_manufacturer = 0
+		naval_manufacturer = 0
+		generic_motorized_equipment_manufacturer = 0
+		generic_artillery_manufacturer = 0
+	}
+
+	ai_strategy = {
+		type = pp_spend_priority
+		id = general
+		value = -1000
+	}
+	ai_strategy = {
+		type = pp_spend_priority
+		id = admiral
+		value = -1000
+	}
+}
+
+MP_1_No_AirUnits = {
+	name = "No Air"
+	desc = ""
+
+	enable = {
+		original_tag = CHI
+		has_game_rule = {
+			rule = CHI_ai_behavior
+			option = CHI_MP_1
+		}
+	}
+	abort = {
+	}
+	
+	ai_strategy = {
+		type = unit_ratio
+		id = fighter
+		value = -1000000
+	}
+	ai_strategy = {
+		type = equipment_production_factor
+		id = fighter
+		value = -1000000
+	}
+	ai_strategy = {
+		type = equipment_variant_production_factor
+		id = fighter_equipment
+		value = -1000000
+	}
+	ai_strategy = {
+		type = equipment_production_factor
+		id = cas
+		value = -10000
+	}
+	ai_strategy = {
+		type = equipment_production_factor
+		id = naval_bomber
+		value = -10000
+	}
+	ai_strategy = {
+		type = equipment_production_factor
+		id = tactical_bomber
+		value = -10000
+	}
+	ai_strategy = {
+		type = equipment_production_factor
+		id = strategic_bomber
+		value = -10000
+	}
+}
+
+CHI_MP_Electronics_1 = {
+	name = "Research Radio"
+	desc = ""
+
+	enable = {
+		original_tag = CHI
+		has_game_rule = {
+			rule = CHI_ai_behavior
+			option = CHI_MP_1
+		}
+		CHI = {
+			is_subject = no
+		}
+		has_completed_focus = CHI_expand_the_academica_sinica
+		NOT = { has_tech = radio }
+	}
+	
+	abort = {
+		CHI = {
+			is_subject = yes
+		}
+		has_tech = radio
+	}
+
+	research = {
+		electronics = 100000
+	}
+}
+
+
+CHI_MP_1_Puppet = {
+	name = "Puppet China Plan 1"
+	desc = "Fight for Japan"
+
+	enable = {
+		original_tag = CHI
+		has_game_rule = {
+			rule = CHI_ai_behavior
+			option = CHI_MP_1
+		}
+		CHI = {
+			is_subject = yes
+		}
+	}
+
+	abort = {
+		CHI = {
+			is_subject = no
+		}
+	}
+
+
+	ai_national_focuses = {
+	}
+
+	research = {
+	cat_anti_tank = 20
+	cat_mass_assault = 100
+	}
+
+	ideas = {
+		extensive_conscription = 100
+		war_economy = 50
+		CHI_soong_mei_ling = 10
+	}
+
+	# Keep small, as it is used as a factor for some things (such as research needs)
+	# Recommended around 1.0. Useful for relation between plans
+	weight = {
+		factor = 1.0
+		modifier = {
+			factor = 1.0
+		}
+	}
+}

--- a/common/ai_strategy_plans/CHI_Warlord_MP_plan.txt
+++ b/common/ai_strategy_plans/CHI_Warlord_MP_plan.txt
@@ -1,0 +1,270 @@
+CHI_warlord_MP_plan_nationalist = {
+	name = "Chinese Warlord MP plan supporting Nationalists"
+	desc = "Scripted behavior for Chinese Warlord"
+
+	enable = {
+		OR = {
+			original_tag = GXC
+			original_tag = YUN
+			original_tag = XSM
+		}
+		has_game_rule = {
+			rule = WL_ai_behavior
+			option = WL_MP_1
+		}
+	}
+
+	abort = {
+		NOT = {
+			has_focus_tree = china_warlord_focus
+		}
+	}
+
+	ai_national_focuses = {
+		CHI_industrial_investment
+		CHI_public_education_reform
+		CHI_local_arms_production
+		CHI_secure_internal_politics
+		CHI_cooperation_with_the_nationalists
+		CHI_technological_cooperation
+		CHI_new_model_province
+		CHI_root_out_corruption
+		CHI_reform_the_administration
+		CHI_land_reform
+		CHI_long_term_economic_planning
+		CHI_local_arms_development
+		CHI_heavy_weapons_development
+	}
+
+	focus_factors = {
+		#Never attempt a take over
+		CHI_join_the_republican_government = 0
+		CHI_power_struggle = 0
+	}
+
+	research = {
+
+	}
+
+	ideas = {
+		export_focus = 0
+		free_trade = 1000
+		GXC_li_zongren = 0
+		GXC_li_jishen = 0
+		YUN_ding_zhipan = 0
+		YUN_zhou_zhirou = 0
+		YUN_liu_wenhui = 0
+		SHX_qu_yangke = 0
+	}
+	
+	ai_strategy = {
+		type = prepare_for_war
+		id = JAP
+		value = 200
+	}
+
+	# Keep small, as it is used as a factor for some things (such as research needs)
+	# Recommended around 1.0. Useful for relation between plans
+	weight = {
+		factor = 1.0
+		modifier = {
+			factor = 1.0
+		}
+	}
+
+}
+
+CHI_warlord_MP_plan_communist = {
+	name = "Communist Chinese Warlord MP plan supporting Nationalists"
+	desc = "Scripted behavior for Chinese Warlord"
+
+	enable = {
+		OR = {
+			original_tag = SHX
+			original_tag = SIK
+		}
+		has_game_rule = {
+			rule = WL_ai_behavior
+			option = WL_MP_1
+		}
+	}
+	abort = {
+		NOT = {
+			has_focus_tree = china_warlord_focus
+		}
+	}
+
+	ai_national_focuses = {
+		CHI_industrial_investment
+		CHI_public_education_reform
+		CHI_local_arms_production
+		CHI_secure_internal_politics
+		CHI_cooperation_with_the_communists
+		CHI_land_redistribution
+		CHI_land_value_tax
+		CHI_communist_administrators
+		CHI_ideological_education
+		CHI_judiciary_reforms
+		CHI_long_term_economic_planning
+		CHI_local_arms_development
+		CHI_heavy_weapons_development
+		CHI_public_works
+		CHI_labor_reform
+		CHI_rural_militias
+	}
+
+	focus_factors = {
+		#Never attempt a take over
+		CHI_join_the_chinese_soviet = 0
+		CHI_the_yanan_incident = 0
+	}
+
+	research = {
+
+	}
+
+	ideas = {
+
+	}
+
+	ai_strategy = {
+		type = prepare_for_war
+		id = JAP
+		value = 200
+	}
+
+	# Keep small, as it is used as a factor for some things (such as research needs)
+	# Recommended around 1.0. Useful for relation between plans
+	weight = {
+		factor = 1.0
+		modifier = {
+			factor = 1.0
+		}
+	}
+}
+
+GXC_ignore_FRA_script = {
+	name = ""
+	desc = ""
+
+	enable = {
+		tag = GXC
+		country_exists = FRA
+		has_game_rule = {
+			rule = WL_ai_behavior
+			option = WL_MP_1
+		}
+	}
+
+	abort = {
+	}
+
+	ai_strategy = {
+		type = ignore
+		id = "FRA"			
+		value = 1000
+	}	
+}
+
+GXC_Infrastructure_1 = {
+	name = ""
+	desc = ""
+
+	enable = {	
+		original_tag = GXC
+		has_game_rule = {
+			rule = WL_ai_behavior
+			option = WL_MP_1
+		}
+		594 = {
+			is_controlled_by = GXC
+			infrastructure < 7
+		}
+	}
+
+	abort = {
+		594 = {
+			OR ={
+				NOT = { is_controlled_by = GXC }
+				NOT = { infrastructure < 7 }
+			}
+		}
+	}
+
+	ai_strategy = {
+		type = build_building
+		id = infrastructure
+		target = 594
+		value = 4
+	}
+}
+
+GXC_Infrastructure_1 = {
+	name = ""
+	desc = ""
+
+	enable = {	
+		original_tag = GXC
+		has_game_rule = {
+			rule = WL_ai_behavior
+			option = WL_MP_1
+		}
+		594 = {
+			is_controlled_by = GXC
+			NOT = { infrastructure < 7 }
+		}
+		592 = {
+			is_controlled_by = GXC
+			infrastructure < 7
+		}
+	}
+
+	abort = {
+		592 = {
+			OR ={
+				NOT = { is_controlled_by = GXC }
+				NOT = { infrastructure < 7 }
+			}
+		}
+	}
+
+	ai_strategy = {
+		type = build_building
+		id = infrastructure
+		target = 592
+		value = 4
+	}
+}
+
+YUN_Infrastructure = {
+	name = ""
+	desc = ""
+
+	enable = {
+		original_tag = YUN
+		has_game_rule = {
+			rule = WL_ai_behavior
+			option = WL_MP_1
+		}
+		325= {
+			is_controlled_by = YUN
+			infrastructure < 10
+		}
+	}
+
+	abort = {
+		325 = {
+			OR ={
+				NOT = { is_controlled_by = YUN }
+				NOT = { infrastructure < 10 }
+			}
+		}
+	}
+
+	ai_strategy = {
+		type = build_building
+		id = infrastructure
+		target = 325
+		value = 10
+	}
+}

--- a/common/ai_strategy_plans/CHI_default_strategy_plan.txt
+++ b/common/ai_strategy_plans/CHI_default_strategy_plan.txt
@@ -1,0 +1,481 @@
+CHI_default_plan = {
+	name = "Nationalist China default plan"
+	desc = "Default behavior for Nationalist China"
+
+	enable = {
+		original_tag = CHI
+	}
+	abort = {
+		always = no
+	}
+
+	focus_factors = {
+	
+	}
+
+	research = {
+
+	}
+
+	ideas = {
+
+	}
+
+	# Keep small, as it is used as a factor for some things (such as research needs)
+	# Recommended around 1.0. Useful for relation between plans
+	weight = {
+		factor = 1
+		modifier = {
+			factor = 1.0
+		}
+	}
+}
+CHI_industrial_buildup = {
+	name = "Nationalist China industrial buildup plan"
+	desc = "Makes Nationalist China more likely to expand industry if not at war"
+
+	enable = {
+		OR = {
+			original_tag = CHI
+			AND = {
+				is_chinese_warlord = yes
+				has_focus_tree = china_nationalist_focus
+			}
+		}
+		has_war = no
+	}
+	abort = {
+		has_war = yes
+	}
+	focus_factors = {
+		CHI_unified_industrial_planning = 5
+		CHI_expand_the_academica_sinica = 10 
+		CHI_rural_reconstruction_movement = 5
+		CHI_financial_policy = 5
+		CHI_mining_commission = 5
+		CHI_taiyuan_arsenal = 5
+		CHI_develop_the_hanyan_arsenal = 5
+	}
+
+	research = {
+		industry = 15.0
+		electronics = 15.0
+	}
+
+	ideas = {
+		CHI_t_v_soong = 5
+		CHI_h_h_kung = 5
+	}
+
+	# Keep small, as it is used as a factor for some things (such as research needs)
+	# Recommended around 1.0. Useful for relation between plans
+	weight = {
+		factor = 1
+		modifier = {
+			factor = 1.0
+		}
+	}
+}
+
+CHI_inflation_handling = {
+	name = "Nationalist China Secret Plan to Fight Inflation"
+	desc = "Teaches the AI to handle the inflation mechanic for China"
+
+	enable = {
+		OR = {
+			original_tag = CHI
+			AND = {
+				is_chinese_warlord = yes
+				has_focus_tree = china_nationalist_focus
+			}
+		}
+		OR = {
+			has_idea = CHI_hyper_inflation_3
+			has_idea = CHI_hyper_inflation_4
+			has_idea = CHI_hyper_inflation_5
+		}
+	}
+	abort = {
+		OR = { #inflation under control
+			has_idea = CHI_hyper_inflation_2
+			has_idea = CHI_hyper_inflation_1
+		}
+	}
+	focus_factors = {
+		CHI_financial_policy = 50
+		CHI_price_controls = 50
+		CHI_reform_the_national_bank = 50
+		CHI_forced_loans = 50
+		CHI_land_tax_reform = 50
+		CHI_develop_the_hanyan_arsenal = 0.0
+		CHI_unemployment_assistance = 0.0
+		CHI_taiyuan_arsenal = 0.0
+		CHI_mining_commission = 0.0
+		CHI_welfare = 0.0
+		CHI_refugee_relief_agency = 0.0
+		CHI_free_hospitals = 0.0
+		CHI_rural_schooling = 0.0
+	}
+
+	research = {
+	}
+
+	ideas = {
+		CHI_t_v_soong = 10
+	}
+
+	# Keep small, as it is used as a factor for some things (such as research needs)
+	# Recommended around 1.0. Useful for relation between plans
+	weight = {
+		factor = 1
+		modifier = {
+			factor = 1.0
+		}
+	}
+}
+
+CHI_army_reform = {
+	name = "Nationalist China Army Reform"
+	desc = "Teaches the AI to reform the Army if at war"
+
+	enable = {
+		original_tag = CHI
+		has_war = yes
+		OR = {
+			has_idea = CHI_army_corruption_1
+			has_idea = CHI_army_corruption_2
+			has_idea = CHI_army_corruption_3
+		}
+	}
+	abort = {
+		NOT = {
+			OR = { 
+				has_idea = CHI_army_corruption_1
+				has_idea = CHI_army_corruption_2
+				has_idea = CHI_army_corruption_3
+			}
+		}
+	}
+	focus_factors = {
+		CHI_army_reform = 50
+		CHI_military_affairs_commission = 50
+	}
+
+	research = {
+	}
+
+	ideas = {
+	}
+
+	# Keep small, as it is used as a factor for some things (such as research needs)
+	# Recommended around 1.0. Useful for relation between plans
+	weight = {
+		factor = 1
+		modifier = {
+			factor = 1.0
+		}
+	}
+}
+CHI_war_measures = {
+	name = "Nationalist China War measures"
+	desc = "Teaches the AI to fix issues if at war"
+
+	enable = {
+		OR = {
+			original_tag = CHI
+			AND = {
+				is_chinese_warlord = yes
+				has_focus_tree = china_nationalist_focus
+			}
+		}
+		has_war = yes
+	}
+	abort = {
+		OR = {
+			has_war = no
+			has_completed_focus = CHI_war_of_national_liberation
+			has_completed_focus = CHI_dare_to_die_corps
+			controls_state = 527 #has successfully taken Manchuria
+		}
+	}
+	focus_factors = {
+		CHI_war_of_resistance = 20
+		CHI_military_affairs_commission = 20
+		CHI_industrial_evacuations = 30
+		CHI_scorched_earth_tactics = 30
+		CHI_democracy = 0 #can't have that nonsense right now
+		CHI_war_of_national_liberation = 20
+	}
+
+	research = {
+		infantry_weapons = 15.0
+		artillery = 15.0
+		air_equipment = 0
+	}
+
+	ideas = {
+	}
+
+	# Keep small, as it is used as a factor for some things (such as research needs)
+	# Recommended around 1.0. Useful for relation between plans
+	weight = {
+		factor = 1
+		modifier = {
+			factor = 1.0
+		}
+	}
+}
+CHI_befriend_britain = {
+	name = "Befirend Britain"
+	desc = "Teaches the AI to make friends with britain to progress further down the tree"
+
+	enable = {
+		NOT = {
+			has_game_rule = {
+				rule = CHI_ai_behavior
+				option = CHI_MP_1
+			}
+		}
+		has_completed_focus = CHI_british_cooperation
+	}
+	abort = {
+		has_completed_focus = CHI_ledo_road #they have served their purpose
+	}
+	focus_factors = {
+		CHI_burma_road = 20
+		CHI_ledo_road = 20
+		CHI_fighter_purchases = 20
+	}
+
+	research = {
+	}
+
+	ideas = {
+	}
+	ai_strategy = {
+		type = befriend
+		id = "ENG"			
+		value = 200
+	}
+
+	# Keep small, as it is used as a factor for some things (such as research needs)
+	# Recommended around 1.0. Useful for relation between plans
+	weight = {
+		factor = 1
+		modifier = {
+			factor = 1.0
+		}
+	}
+}
+CHI_befriend_america = {
+	name = "Befirend America"
+	desc = "Teaches the AI to make friends with britain to progress further down the tree"
+
+	enable = {
+		NOT = {
+			has_game_rule = {
+				rule = CHI_ai_behavior
+				option = CHI_MP_1
+			}
+		}
+		has_completed_focus = CHI_mission_to_the_us
+	}
+	abort = {
+		has_completed_focus = CHI_the_hump #they have served their purpose
+	}
+	focus_factors = {
+		CHI_the_hump = 20
+		CHI_hire_chennault = 20
+		CHI_fighter_purchases = 20
+		CHI_invite_the_flying_tigers = 20
+	}
+
+	research = {
+	}
+
+	ideas = {
+	}
+	ai_strategy = {
+		type = befriend
+		id = "USA"			
+		value = 200
+	}
+
+	# Keep small, as it is used as a factor for some things (such as research needs)
+	# Recommended around 1.0. Useful for relation between plans
+	weight = {
+		factor = 1
+		modifier = {
+			factor = 1.0
+		}
+	}
+}
+CHI_befriend_France = {
+	name = "Befirend France"
+	desc = "Teaches the AI to make friends with britain to progress further down the tree"
+
+	enable = {
+		NOT = {
+			has_game_rule = {
+				rule = CHI_ai_behavior
+				option = CHI_MP_1
+			}
+		}
+		has_completed_focus = CHI_reach_out_to_france
+	}
+	abort = {
+		has_completed_focus = CHI_french_drill #they have served their purpose
+	}
+	focus_factors = {
+		CHI_guarantee_the_hanoi_route = 30
+		CHI_french_military_mission = 20
+		CHI_french_drill = 20
+		CHI_small_arms_expertise = 20
+	}
+
+	research = {
+	}
+
+	ideas = {
+	}
+	ai_strategy = {
+		type = befriend
+		id = "FRA"			
+		value = 200
+	}
+
+	# Keep small, as it is used as a factor for some things (such as research needs)
+	# Recommended around 1.0. Useful for relation between plans
+	weight = {
+		factor = 1
+		modifier = {
+			factor = 1.0
+		}
+	}
+}
+CHI_befriend_Soviet = {
+	name = "Befirend Soviet"
+	desc = "Teaches the AI to make friends with Soviet to progress further down the tree"
+
+	enable = {
+		NOT = {
+			has_game_rule = {
+				rule = CHI_ai_behavior
+				option = CHI_MP_1
+			}
+		}
+		has_completed_focus = CHI_mission_to_the_soviet_union
+	}
+	abort = {
+		has_completed_focus = CHI_combined_arms_warfare #they have served their purpose
+	}
+	focus_factors = {
+		CHI_the_soviet_volunteer_group = 20
+		CHI_rapprochement_with_soviet_union = 20
+		CHI_purchase_tanks = 20
+		CHI_experimental_mechanised_unit = 20
+		CHI_invite_soviet_advisers = 20
+		CHI_heavy_weapons = 20
+	}
+
+	research = {
+		motorized_equipment = 15.0 #needed to progress
+	}
+
+	ideas = {
+	}
+	ai_strategy = {
+		type = befriend
+		id = "SOV"			
+		value = 200
+	}
+
+	# Keep small, as it is used as a factor for some things (such as research needs)
+	# Recommended around 1.0. Useful for relation between plans
+	weight = {
+		factor = 1
+		modifier = {
+			factor = 1.0
+		}
+	}
+}
+
+CHI_european_allies = { #used to make minor European nations like Axis more
+	name = "Minor European Countries"
+
+	enable = {
+		has_war = yes
+		OR = {
+			is_in_faction = no
+			is_faction_leader = yes
+		}
+		OR = {
+			original_tag = ROM
+			original_tag = HUN
+			original_tag = BUL
+			original_tag = YUG
+			original_tag = ITA
+			original_tag = CZE
+			original_tag = DEN
+			original_tag = NOR
+			original_tag = SWE
+			original_tag = FIN
+			original_tag = SPR
+			original_tag = POR
+			original_tag = HOL
+			original_tag = BEL
+			original_tag = LUX
+			original_tag = POL
+			original_tag = LAT
+			original_tag = LIT
+			original_tag = EST
+			original_tag = CRO
+			original_tag = SLO
+		}
+	}
+	abort = {
+		OR = {
+			has_war = no
+			AND = {
+				is_in_faction = yes
+				is_faction_leader = no
+			}
+		}
+	}
+
+	ai_strategy = {
+		type = alliance
+		id = "CHI"
+		value = -500
+	}
+	ai_strategy = {
+		type = alliance
+		id = "PRC"
+		value = -500
+	}
+	ai_strategy = {
+		type = alliance
+		id = "GXC"
+		value = -500
+	}
+	ai_strategy = {
+		type = alliance
+		id = "YUN"
+		value = -500
+	}
+	ai_strategy = {
+		type = alliance
+		id = "XSM"
+		value = -500
+	}
+	ai_strategy = {
+		type = alliance
+		id = "SHX"
+		value = -500
+	}
+	ai_strategy = {
+		type = alliance
+		id = "SIK"
+		value = -500
+	}
+}

--- a/common/ai_strategy_plans/CHI_warlord_historical_strategy_plan.txt
+++ b/common/ai_strategy_plans/CHI_warlord_historical_strategy_plan.txt
@@ -1,0 +1,126 @@
+CHI_warlord_historical_plan_nationalist = {
+	name = "Chinese Warlord historical plan supporting Nationalists"
+	desc = "Historical behavior for Chinese Warlord"
+
+	enable = {
+		OR = {
+			original_tag = GXC
+			original_tag = YUN
+			original_tag = XSM
+		}
+		is_historical_focus_on = yes
+		has_game_rule = {
+			rule = WL_ai_behavior
+			option = DEFAULT
+		}
+	}
+	abort = {
+		NOT = {
+			has_focus_tree = china_warlord_focus
+		}
+	}
+
+	ai_national_focuses = {
+		CHI_secure_internal_politics
+		CHI_cooperation_with_the_nationalists
+		CHI_industrial_investment
+		CHI_public_education_reform
+		CHI_long_term_economic_planning
+		CHI_technological_cooperation
+		CHI_local_arms_production
+		CHI_new_model_province
+		CHI_root_out_corruption
+		CHI_land_reform
+		CHI_reform_the_administration
+		CHI_heavy_weapons_development
+	}
+
+	focus_factors = {
+		#Never attempt a take over
+		CHI_join_the_republican_government = 0
+		CHI_power_struggle = 0
+	}
+
+	research = {
+
+	}
+
+	ideas = {
+
+	}
+
+	# Keep small, as it is used as a factor for some things (such as research needs)
+	# Recommended around 1.0. Useful for relation between plans
+	weight = {
+		factor = 1.0
+		modifier = {
+			factor = 1.0
+		}
+	}
+
+}
+
+CHI_warlord_historical_plan_communist = {
+	name = "Chinese Warlord historical plan supporting Communists"
+	desc = "Historical behavior for Chinese Warlord"
+
+	enable = {
+		OR = {
+			original_tag = SHX
+			original_tag = SIK
+		}
+		is_historical_focus_on = yes
+		has_game_rule = {
+			rule = WL_ai_behavior
+			option = DEFAULT
+		}
+	}
+	abort = {
+		NOT = {
+			has_focus_tree = china_warlord_focus
+		}
+	}
+
+	ai_national_focuses = {
+		CHI_secure_internal_politics
+		CHI_cooperation_with_the_communists
+		CHI_land_redistribution
+		CHI_land_value_tax
+		CHI_judiciary_reforms
+		CHI_communist_administrators
+		CHI_industrial_investment
+		CHI_public_education_reform
+		CHI_local_arms_production
+		CHI_long_term_economic_planning
+		CHI_ideological_education
+		CHI_local_arms_development
+		CHI_heavy_weapons_development
+		CHI_public_works
+		CHI_labor_reform
+		CHI_rural_militias
+	}
+
+	focus_factors = {
+		#Never attempt a take over
+		CHI_join_the_chinese_soviet = 0
+		CHI_the_yanan_incident = 0
+	}
+
+	research = {
+
+	}
+
+	ideas = {
+
+	}
+
+	# Keep small, as it is used as a factor for some things (such as research needs)
+	# Recommended around 1.0. Useful for relation between plans
+	weight = {
+		factor = 1.0
+		modifier = {
+			factor = 1.0
+		}
+	}
+
+}

--- a/common/ai_strategy_plans/ENG_MP_plan.txt
+++ b/common/ai_strategy_plans/ENG_MP_plan.txt
@@ -1,0 +1,97 @@
+ENG_MP_1 = {
+	name = "United Kingdom MP1 plan"
+	desc = "Mulitplayer script behavior for United Kingdom"
+
+	enable = {
+		original_tag = ENG
+		has_dlc = "Man the Guns"
+		has_game_rule = {
+			rule = ENG_ai_behavior
+			option = ENG_MP_1
+			}
+		}
+
+	abort = {
+	}
+
+	ai_national_focuses = {
+		limited_rearmament_focus
+		general_rearmament_focus
+		air_rearmament_focus
+		fighter_command_focus
+		shadow_scheme_focus	
+		uk_industrial_focus
+		uk_extra_tech_slot
+		royal_ordinance_focus
+		ENG_steady_as_she_goes
+		ENG_home_defence
+		ENG_issue_gasmasks
+		uk_empire_focus
+		uk_service_focus
+		uk_colonial_focus		
+		ENG_military_training_act
+		aircraft_production_focus
+		ENG_prepare_for_the_inevitable
+		uk_small_arms_focus
+		crypto_bomb_focus
+		tizard_mission_focus
+		air_defense_focus
+		radar_focus		
+		uk_commonwealth_focus
+		uk_india_focus
+		ENG_indian_autonomy
+		ENG_special_air_service
+		naval_rearmament_focus
+		uk_destroyer_focus
+		uk_convoy_focus
+		ENG_chiefs_of_staff_committee
+		uk_mediterranean_focus
+ 		uk_protect_suez
+		uk_malta_focus
+ 		uk_rock_focus
+		uk_amphibious_focus
+	}
+
+	research = {
+
+	}
+
+	ideas = {
+		ENG_philip_kerr = 1000
+		low_economic_mobilisation = 300
+		partial_economic_mobilisation = 400
+		war_economy = 500
+		harold_alexander = 10
+		supermarine = 5
+	}
+
+	# Keep small, as it is used as a factor for some things (such as research needs)
+	# Recommended around 1.0. Useful for relation between plans
+	weight = {
+		factor = 1.0
+		modifier = {
+			factor = 1.0
+		}
+	}
+
+}
+
+ENG_MP_AirDoctrine = {
+	name = "Air Doctrine Research"
+	desc = ""
+
+	enable = {
+		original_tag = ENG
+		has_game_rule = {
+			rule = ENG_ai_behavior
+			option = ENG_MP_1
+		}
+	has_tech = logistical_bombing
+	}
+	abort = { 
+	}
+	
+	research = {
+		cat_strategic_destruction = -1000
+	}
+}

--- a/common/ai_strategy_plans/ETH_MP_plan.txt
+++ b/common/ai_strategy_plans/ETH_MP_plan.txt
@@ -1,0 +1,106 @@
+ETH_MP_Free = {
+	name = "Ethopia Free 1"
+	desc = ""
+
+	enable = {
+		original_tag = ETH
+		has_game_rule = {
+			rule = ETH_ai_behavior
+			option = ETH_MP_1
+		}
+		ETH = {
+			NOT = { is_subject_of = ITA }
+		}
+	}
+
+	abort = {
+		ETH = {
+			is_subject_of = ITA
+		}
+	}
+	focus_factors = {
+		internationalism_focus = 0
+		liberty_ethos = 0
+		
+	}
+}
+
+ETH_MP_Subject = {
+	name = "Ethopia Subject 1"
+	desc = ""
+
+	enable = {
+		original_tag = ETH
+		has_game_rule = {
+			rule = ETH_ai_behavior
+			option = ETH_MP_1
+		}
+		ETH = {
+			is_subject_of = ITA
+		}
+	}
+
+	abort = {
+		ETH = {
+			NOT = {
+				is_subject_of = ITA
+			}
+		}
+	}
+
+	ai_national_focuses = {
+		political_effort
+		collectivist_ethos
+		nationalism_focus
+		militarism
+		industrial_effort
+		construction_effort
+		construction_effort_2
+		infrastructure_effort
+		infrastructure_effort_2
+		extra_tech_slot
+		extra_tech_slot_2
+		construction_effort_3
+		production_effort
+		production_effort_2
+		production_effort_3
+		naval_effort
+		army_effort
+		doctrine_effort
+		doctrine_effort_2
+		aviation_effort
+		fighter_focus
+	}
+
+	research = {
+		air_equipment = -10000
+		air_doctrine = -10000
+		naval_equipment = -10000
+		naval_doctrine = -10000
+	}
+
+	ideas = {
+		war_economy = 100
+		extensive_conscription = 100
+	}
+	
+		
+	ai_strategy = {
+	}
+
+	traits = {
+	}
+
+	# Keep small, as it is used as a factor for some things (such as research needs)
+	# Recommended around 1.0. Useful for relation between plans
+	weight = {
+		factor = 1.0
+		modifier = {
+			factor = 1.0
+		}
+	}
+
+	focus_factors = {
+		
+	}
+}

--- a/common/ai_strategy_plans/FRA_MP_plan.txt
+++ b/common/ai_strategy_plans/FRA_MP_plan.txt
@@ -1,0 +1,703 @@
+FRA_MP_1 = {
+	name = "France Multiplayer 1"
+	desc = "Revive the National Bloc"
+
+	enable = {
+		original_tag = FRA
+			has_game_rule = {
+				rule = FRA_ai_behavior
+				option = FRA_MP_1
+			}	
+	}
+
+	abort = {
+	}
+
+	ai_national_focuses = {
+		FRA_revive_the_national_bloc
+		FRA_laissez_faire
+		FRA_protect_the_rights_of_man
+		FRA_review_foreign_policy
+		FRA_buy_time
+		#1937
+		FRA_strengthen_government_support
+		FRA_defensive_strategems
+		FRA_intervention_in_spain
+		FRA_begin_rearmament
+		FRA_economic_devolution
+		#1938		
+		FRA_defensive_focus
+		FRA_firepower_kills
+		FRA_infantry_focus
+		FRA_artillery_focus
+		FRA_heavy_armor_focus
+		#1939
+		FRA_army_reform
+		FRA_go_with_britain
+		FRA_ban_communism
+		FRA_the_blum_viollette_proposal
+		FRA_expand_the_citizenship
+		FRA_encourage_immigration
+		#1940
+		FRA_arms_purchases_in_the_us
+		FRA_devalue_the_franc
+		FRA_invest_in_the_colonies
+		FRA_algerie_france
+		FRA_invest_in_west_africa
+		#1941
+		FRA_invest_in_syria
+		FRA_colonial_industry
+		FRA_extra_research_slot_2
+		FRA_invest_in_the_metropole
+		FRA_industrial_expansion 
+		#1942
+		FRA_extra_research_slot
+	}
+
+	research = {
+		synth_resources = -1000
+		air_doctrine = -1000
+		naval_equipment = -1000
+		naval_doctrine = -1000
+	}
+
+	ideas = {
+		war_economy = 200
+		partial_economic_mobilisation = 100
+		FRA_gaston_henry_haye = 1000
+		henri_giraud = 30
+		maxime_weygand = 20
+		FRA_zivony_peshkov = 20
+		FRA_paul_baudouin = 0
+		FRA_charles_tillon = 0
+		charles_de_gaulle = 0
+		louis_kahn = 0
+		jean_decoux = 0
+		victor_denain = 0
+		jean_marie_bergeret = 0
+		frederic_irene_joliot_curie = 0
+	}
+
+	ai_strategy = {
+	}
+
+
+	# Keep small, as it is used as a factor for some things (such as research needs)
+	# Recommended around 1.0. Useful for relation between plans
+	weight = {
+		factor = 1.0
+		modifier = {
+			factor = 1.0
+		}
+	}
+
+}
+
+FRA_MP_2 = {
+	name = "France Multiplayer 2"
+	desc = "Form the Popular Front"
+
+	enable = {
+		original_tag = FRA
+			has_game_rule = {
+				rule = FRA_ai_behavior
+				option = FRA_MP_2
+			}	
+	}
+
+	abort = {
+	}
+
+	ai_national_focuses = {
+		FRA_form_the_popular_front
+		FRA_reform_the_labour_laws
+		FRA_review_foreign_policy
+		FRA_buy_time
+		FRA_strengthen_government_support
+		#1937
+		FRA_defensive_strategems
+		FRA_ban_the_leagues
+		FRA_begin_rearmament
+		FRA_nationalize_key_industry
+		FRA_form_the_state_arsenals
+		#1938
+		FRA_defensive_focus
+		FRA_firepower_kills
+		FRA_infantry_focus
+		FRA_artillery_focus
+		FRA_heavy_armor_focus
+		#1939
+		FRA_army_reform
+		FRA_go_with_britain
+		FRA_the_blum_viollette_proposal
+		FRA_expand_the_citizenship
+		FRA_encourage_immigration
+		#1940
+		FRA_devalue_the_franc
+		FRA_invest_in_the_colonies
+		FRA_algerie_france
+		FRA_invest_in_west_africa
+		FRA_invest_in_syria
+		#1941
+		FRA_colonial_industry
+		FRA_extra_research_slot_2
+		FRA_invest_in_the_metropole
+		FRA_industrial_expansion
+		FRA_extra_research_slot
+		#1942
+		
+		
+		 
+		
+	}
+
+	research = {
+		synth_resources = -1000
+		air_doctrine = -1000
+		naval_equipment = -1000
+		naval_doctrine = -1000
+	}
+
+	ideas = {
+		war_economy = 200
+		partial_economic_mobilisation = 100
+		FRA_gaston_henry_haye = 1000
+		henri_giraud = 30
+		maxime_weygand = 20
+		FRA_zivony_peshkov = 20
+		FRA_paul_baudouin = 0
+		FRA_charles_tillon = 0
+		charles_de_gaulle = 0
+		louis_kahn = 0
+		jean_decoux = 0
+		victor_denain = 0
+		jean_marie_bergeret = 0
+		frederic_irene_joliot_curie = 0
+	}
+
+	ai_strategy = {
+	}
+
+	# Keep small, as it is used as a factor for some things (such as research needs)
+	# Recommended around 1.0. Useful for relation between plans
+	weight = {
+		factor = 1.0
+		modifier = {
+			factor = 1.0
+		}
+	}
+
+}
+
+FRA_MP_Advisors = {
+	name = "Blocked Advisors till capitulated or Mid-1940"
+	desc = ""
+
+	enable = {
+		original_tag = FRA
+		OR = {
+			has_game_rule = {
+				rule = FRA_ai_behavior
+				option = FRA_MP_1
+			}
+			has_game_rule = {
+				rule = FRA_ai_behavior
+				option = FRA_MP_2
+			}
+		}
+		OR = {
+			FRA = { has_capitulated = no }
+			date < 1940.6.1
+		}
+	}
+
+	abort = {
+		OR = {
+			FRA = { has_capitulated = yes }
+			date > 1940.6.1
+		}
+	}
+
+	ideas = {
+		FRA_felix_gouin = 0
+		FRA_paul_reynaud = 0
+		francois_darlan = 0
+		marcel_gensoul = 0
+		jean_marie_abrial = 0
+		joseph_vuillemin = 0
+		robert_odic = 0
+		philippe_fequant = 0
+		rene_prioux = 0
+		charles_huntziger = 0
+		philippe_leclerc = 0
+		alfred_heurtaux = 0
+		martial_valin = 0
+		jean_francois_jannekeyn = 0
+		jean_de_laborde = 0
+		emile_muselier = 0
+		rene_emile_godfroy = 0
+		renault_fra = 0
+		FRA_AMX = 0
+		somua = 0
+		mas = 0
+		schneider = 0
+		morane_saulnier = 0
+		bloch = 0
+		amiot = 0
+		levasseur = 0
+		fcm = 0
+		famh = 0
+	}
+	
+	ai_strategy = {
+		type = pp_spend_priority
+		id = general
+		value = -1000
+	}
+
+	ai_strategy = {
+		type = pp_spend_priority
+		id = admiral
+		value = -1000
+	}
+}
+
+FRA_MP_NoBomber = {
+	name = "No Bomber Production"
+	desc = ""
+
+	enable = {
+		original_tag = FRA
+		OR = {
+			has_game_rule = {
+				rule = FRA_ai_behavior
+				option = FRA_MP_1
+			}
+			has_game_rule = {
+				rule = FRA_ai_behavior
+				option = FRA_MP_2
+			}
+		}
+	}
+
+	abort = {
+	}
+
+	ai_strategy = {
+		type = equipment_production_factor
+		id = fighter
+		value = -10000
+	}	
+	ai_strategy = {
+		type = equipment_production_factor
+		id = cas
+		value = -10000
+	}
+	ai_strategy = {
+		type = equipment_production_factor
+		id = naval_bomber
+		value = -10000
+	}
+	ai_strategy = {
+		type = equipment_production_factor
+		id = tactical_bomber
+		value = -10000
+	}
+	ai_strategy = {
+		type = equipment_production_factor
+		id = strategic_bomber
+		value = -10000
+	}
+}
+
+FRA_MP_NoLandDoctrine = {
+	name = "No Landdoctrine until Army reformed"
+	desc = ""
+
+	enable = {
+		original_tag = FRA
+		OR = {
+			has_game_rule = {
+				rule = FRA_ai_behavior
+				option = FRA_MP_1
+			}
+			has_game_rule = {
+				rule = FRA_ai_behavior
+				option = FRA_MP_2
+			}
+		}
+		has_idea = FRA_victors_of_wwi
+	}
+	
+	abort = {
+		NOT { has_idea = FRA_victors_of_wwi }
+	}
+	
+	research = {
+		land_doctrine = -10000
+	}
+}
+
+FRA_MP_AT_Research = {
+	name = "Research Anti-Tank Guns"
+	desc = ""
+
+	enable = {
+		original_tag = FRA
+		OR = {
+			has_game_rule = {
+				rule = FRA_ai_behavior
+				option = FRA_MP_1
+			}
+			has_game_rule = {
+				rule = FRA_ai_behavior
+				option = FRA_MP_2
+			}
+		}
+		date > 1937.06.01
+	}
+
+	abort = {
+	}
+
+	research = {
+		cat_anti_tank = 10000
+	}
+
+}
+
+FRA_MP_AT_Production = {
+	name = "Produce Anti-Tank Guns"
+	desc = ""
+
+	enable = {
+		original_tag = FRA
+		OR = {
+			has_game_rule = {
+				rule = FRA_ai_behavior
+				option = FRA_MP_1
+			}
+			has_game_rule = {
+				rule = FRA_ai_behavior
+				option = FRA_MP_2
+			}
+		}
+		has_tech = antitank2
+	}
+
+	abort = {
+	}
+
+	ai_strategy = {
+		type = equipment_production_factor
+		id = anti_tank
+		value = 200
+	}
+
+}
+
+FRA_MP_InfEquip_LessProduction = {
+	name = "Produce Less Inf Equip"
+	desc = ""
+
+	enable = {
+		original_tag = FRA
+		OR = {
+			has_game_rule = {
+				rule = FRA_ai_behavior
+				option = FRA_MP_1
+			}
+			has_game_rule = {
+				rule = FRA_ai_behavior
+				option = FRA_MP_2
+			}
+		}
+		has_tech = antitank2
+		stockpile_ratio = {
+			archetype = infantry_equipment
+			ratio > 1.0
+		}
+	}
+
+	abort = {
+		stockpile_ratio = {
+			archetype = infantry_equipment
+			ratio < 0.5
+		}
+	}
+
+	ai_strategy = {
+		type = equipment_production_factor
+		id = infantry
+		value = -50
+	}
+}
+
+FRA_MP_AT_MoreProduction = {
+	name = "Produce Less Armor"
+	desc = ""
+
+	enable = {
+		original_tag = FRA
+		OR = {
+			has_game_rule = {
+				rule = FRA_ai_behavior
+				option = FRA_MP_1
+			}
+			has_game_rule = {
+				rule = FRA_ai_behavior
+				option = FRA_MP_2
+			}
+		}
+		has_tech = antitank2
+	}
+
+	abort = {
+	}
+
+	ai_strategy = {
+		type = equipment_production_factor
+		id = armor
+		value = -50
+	}
+}
+
+FRA_MP_Europe = {
+	name = "Solely Focus on Europe against Germany and Italy"
+	desc = ""
+
+	enable = {
+		original_tag = FRA
+		OR = {
+			has_game_rule = {
+				rule = FRA_ai_behavior
+				option = FRA_MP_1
+			}
+			has_game_rule = {
+				rule = FRA_ai_behavior
+				option = FRA_MP_2
+			}
+		}
+		date < 1940.6.1
+	}
+
+	abort = {
+		date > 1940.6.1
+	}
+
+	ai_strategy = {
+		type = area_priority
+		id = europe
+		value = 10000
+	}
+	ai_strategy = {
+		type = area_priority
+		id = asia
+		value = -10000
+	}
+	ai_strategy = {
+		type = area_priority
+		id = africa
+		value = -10000
+	}
+	ai_strategy = {
+		type = area_priority
+		id = suez
+		value = -10000
+	}
+	ai_strategy = {
+		type = ignore
+		id = BRA
+		value = 1000
+	}
+	ai_strategy = {
+		type = ignore
+		id = SPR
+		value = 1000
+	}
+	ai_strategy = {
+		type = ignore
+		id = SPA
+		value = 1000
+	}
+	ai_strategy = {
+		type = ignore
+		id = LIB
+		value = 1000
+	}
+	ai_strategy = {
+		type = ignore
+		id = TUR
+		value = 1000
+	}
+	ai_strategy = {
+		type = ignore
+		id = IRQ
+		value = 1000
+	}
+	ai_strategy = {
+		type = ignore
+		id = GXC
+		value = 1000
+	}
+	ai_strategy = {
+		type = ignore
+		id = YUN
+		value = 1000
+	}
+	ai_strategy = {
+		type = ignore
+		id = SIA
+		value = 1000
+	}
+}
+
+
+FRA_MP_Belgium = {
+	name = "Prepare some troops on the Belgian Border"
+	desc = ""
+
+	enable = {
+		original_tag = FRA
+		OR = {
+			has_game_rule = {
+				rule = FRA_ai_behavior
+				option = FRA_MP_1
+			}
+			has_game_rule = {
+				rule = FRA_ai_behavior
+				option = FRA_MP_2
+			}
+		}
+		date < 1940.6.1
+	}
+
+	abort = {
+		date > 1940.6.1
+	}
+	
+	ai_strategy = {
+		type = prepare_for_war
+		id = BEL
+		value = 100
+	
+	}
+}
+
+FRA_MP_Axis = {
+	name = "Prepare Troops on the Axis Border"
+	desc = ""
+
+	enable = {
+		original_tag = FRA
+		OR = {
+			has_game_rule = {
+				rule = FRA_ai_behavior
+				option = FRA_MP_1
+			}
+			has_game_rule = {
+				rule = FRA_ai_behavior
+				option = FRA_MP_2
+			}
+		}
+		date < 1940.1.1
+	}
+
+	abort = { date > 1940.1.1
+	}
+	
+	ai_strategy = {
+		type = conquer
+		id = GER
+		value = 400
+	}
+	ai_strategy = {
+		type = conquer
+		id = ITA
+		value = 200
+	}
+}
+
+FRA_MP_Antagonize = {
+	name = "Antagonize Axis for no Trade"
+	desc = ""
+
+	enable = {
+		original_tag = FRA
+		OR = {
+			has_game_rule = {
+				rule = FRA_ai_behavior
+				option = FRA_MP_1
+			}
+			has_game_rule = {
+				rule = FRA_ai_behavior
+				option = FRA_MP_2
+			}
+		}
+	}
+
+	abort = {
+	}
+	
+	ai_strategy = {
+		type = antagonize
+		id = JAP
+		value = 200
+	}
+	ai_strategy = {
+		type = antagonize
+		id = ROM
+		value = 200
+	}
+	ai_strategy = {
+		type = antagonize
+		id = HUN
+		value = 200
+	}
+}
+
+MP_Spy_Defense = {
+	name = "Spy Defense"
+	desc = ""
+
+	enable = {
+		original_tag = FRA
+		OR = {
+			has_game_rule = {
+				rule = FRA_ai_behavior
+				option = FRA_MP_1
+			}
+			has_game_rule = {
+				rule = FRA_ai_behavior
+				option = FRA_MP_2
+			}
+		}
+		date < 1938.1.1	
+	}
+
+	abort = {
+		date > 1938.1.1
+	}
+
+	ai_strategy = {
+		type = intelligence_agency_usable_factories
+		value = 5
+	}
+	ai_strategy = {
+		type = intelligence_agency_usable_factories
+		value = 5
+	}
+	ai_strategy = {
+		type = agency_ai_base_num_factories_factor
+		value = -100    # -100% on the define
+	}
+	ai_strategy = {
+		type = agency_ai_per_upgrade_factories_factor
+		value = -100    # -100% on the define
+	}
+	ai_strategy = {
+		type = operative_mission
+		mission = counter_intelligence
+		value = 100
+	}
+}

--- a/common/ai_strategy_plans/GER_MP_plan.txt
+++ b/common/ai_strategy_plans/GER_MP_plan.txt
@@ -1,0 +1,187 @@
+GER_MP_1 = {
+	name = "GER_MP_1"
+	desc = "RULE_GER_MP_1_DESC"
+
+	enable = {
+		original_tag = GER
+		has_game_rule = {
+			rule = GER_ai_behavior
+			option = GER_MP_1
+		}
+	}
+
+	abort = {
+	}
+
+	ai_national_focuses = {
+		GER_rhineland
+		GER_four_year_plan
+		GER_autarky
+		GER_hermann_goring_werke
+		GER_kdf_wagen
+		#1937
+		GER_extra_tech_slot
+		GER_autobahn
+		GER_german_war_economy
+		GER_army_innovation
+		GER_soviet_treaty
+		#1938
+		GER_army_innovation_2
+		GER_anschluss
+		GER_demand_sudetenland
+		GER_first_vienna_award
+		GER_end_of_czechoslovakia
+		#1939
+		GER_demand_memel
+		GER_west_wall
+		GER_mol_rib_pact
+		GER_danzig_or_war
+		#1940
+		GER_around_maginot
+		GER_coal_liquidization
+		GER_synthetic_rubber
+		GER_weserubung
+		GER_war_with_france
+		GER_air_innovation
+		#1941
+		GER_tactical_air_effort
+		GER_air_innovation_2
+		GER_atlantikwall
+		GER_anti_comitern_pact
+		GER_second_vienna_award
+		GER_italy_ally
+		GER_ussr_war_goal
+	}
+
+	research = {
+		infantry_weapons = 50.0
+		infantry_tech = 15.0
+		artillery = 8.0
+		support_tech = 6.5
+	}
+
+	ideas = {
+		hjalmar_schacht = 60
+		heinrich_himmler = -100
+		martin_bormann = 100
+		walther_funk = 20
+		joseph_goebbels = 30
+		rudolf_hess = -100
+		messerschmitt = 5
+		krupp = 25
+		goering = 0.5
+		werner_von_fritsch = 0.3
+		closed_economy = 0
+	}
+
+	ai_strategy = {
+	}
+	
+
+	traits = {
+		captain_of_industry = 5
+	}
+
+	# Keep small, as it is used as a factor for some things (such as research needs)
+	# Recommended around 1.0. Useful for relation between plans
+	weight = {
+		factor = 1.0
+		modifier = {
+			factor = 1.0
+		}
+	}
+
+	focus_factors = {
+		
+	}
+}
+
+GER_MP_1_NoWar = {
+	name = "Dont join Italian wars"
+	desc = ""
+
+	enable = {
+		original_tag = GER
+		has_game_rule = {
+			rule = GER_ai_behavior
+			option = GER_MP_1
+		}
+	}
+
+	abort = {
+
+	}
+
+	ai_strategy = {
+		type = dont_join_wars_with
+		id = ITA
+		target_country = GRE
+		value = 500
+	}
+	ai_strategy = {
+		type = dont_join_wars_with
+		id = ITA
+		target_country = YUG
+		value = 500
+	}
+}
+
+GER_MP_Alliance = {
+	name = "Ally Hungary and Romania"
+	desc = ""
+
+	enable = {
+		original_tag = GER
+		has_game_rule = {
+			rule = GER_ai_behavior
+			option = GER_MP_1
+		}
+	}
+
+	abort = {
+
+	}
+
+	ai_strategy = {
+		type = alliance
+		id = "HUN"
+		value = 400
+	}
+	ai_strategy = {
+		type = alliance
+		id = "ROM"
+		value = 400
+	}
+	ai_strategy = {
+		type = befriend
+		id = ITA
+		value = 200
+	}
+	ai_strategy = {
+		type = befriend
+		id = JAP
+		value = 200
+	}
+}
+
+Do_Befriend_But_No_PP = {
+	name = ""
+	desc = ""
+
+	enable = {
+		tag = GER
+		has_game_rule = {
+			rule = GER_ai_behavior
+			option = GER_MP_1
+		}
+	}
+
+	abort = {
+	}
+
+	ai_strategy = {
+		type = pp_spend_priority
+		id = relation	
+		value = -200
+	}	
+}

--- a/common/ai_strategy_plans/HUN_MP_plan.txt
+++ b/common/ai_strategy_plans/HUN_MP_plan.txt
@@ -1,0 +1,219 @@
+HUN_MP_1 = {
+	name = "Hungary Multiplayer 1"
+	desc = "Horthy as Dictator, get South Slovakia"
+
+	enable = {
+		original_tag = HUN
+		has_dlc = "Death or Dishonor"
+		has_game_rule = {
+			rule = HUN_ai_behavior
+			option = HUN_MP_1
+		}
+	}
+	
+	abort = {
+	}
+
+	ai_national_focuses = {
+		HUN_economic_intervention
+		HUN_strengthen_fascists
+		HUN_renounce_the_treaty_of_trianon
+		HUN_trade_deal_with_germany
+		HUN_industrial_revitalization
+		HUN_reintegrate_the_railroads
+		HUN_support_domestic_industry
+		HUN_support_urbanization
+		HUN_institute_for_industrial_techniques
+		HUN_reaffirm_territorial_claims
+		HUN_demand_southern_slovakia
+		HUN_announce_the_gyor_program
+		HUN_domestic_arms_industry
+		HUN_aeronautic_technology_institute
+		HUN_secret_rearmament
+		HUN_theoretical_air_efforts
+		HUN_bled_agreement
+		HUN_boost_hungarian_aviation_industry
+		HUN_establish_the_air_force
+		HUN_indigenous_designs
+		HUN_light_fighter_effort
+		HUN_joint_aluminum_mining_company
+	}
+
+	research = {
+		armor = -100
+		cat_mobile_warfare = -1000
+		cat_grand_battle_plan = -1000
+		cat_strategic_destruction = -1000
+		cat_operational_integrity = -1000
+		synth_resources = -1000
+	}
+
+	ideas = {
+		HUN_zoltan_tildy = 100
+		free_trade = 15000
+		export_focus = 0
+		limited_exports = 0
+		closed_economy = 0
+		HUN_lajos_remenyi_schneller = 20
+		HUN_mavag = 10
+		HUN_shvoy_kalman = -100
+		HUN_gyorgy_jendrassik = 3
+		war_economy = 100
+		limited_conscription = 10
+		extensive_conscription = 20
+	}
+
+	ai_strategy = {
+	}
+
+	traits = {
+	}
+
+	# Keep small, as it is used as a factor for some things (such as research needs)
+	# Recommended around 1.0. Useful for relation between plans
+	weight = {
+		factor = 1.0
+		modifier = {
+			factor = 1.0
+		}
+	}
+
+	focus_factors = {
+		HUN_claim_transylvania = 0
+		HUN_claim_overlordship_over_slovakia = 0
+	}
+
+}
+
+HUN_MP_2 = {
+	name = "Hungary Multiplayer 2"
+	desc = "Elect Fascist King"
+
+	enable = {
+		original_tag = HUN
+		has_dlc = "Death or Dishonor"
+		has_game_rule = {
+			rule = HUN_ai_behavior
+			option = HUN_MP_2
+		}
+	}
+	
+	abort = {
+	}
+
+	ai_national_focuses = {
+		HUN_balanced_budget
+		HUN_strengthen_the_monarchists
+		HUN_elect_a_king
+		HUN_elect_a_fascist_king
+		HUN_industrial_revitalization
+		HUN_reintegrate_the_railroads
+		HUN_support_domestic_industry
+		HUN_support_urbanization
+		HUN_institute_for_industrial_techniques
+		HUN_renounce_the_treaty_of_trianon
+		HUN_announce_the_gyor_program
+		HUN_domestic_arms_industry
+		HUN_aeronautic_technology_institute
+		HUN_secret_rearmament
+		HUN_theoretical_air_efforts
+		HUN_bled_agreement
+		HUN_boost_hungarian_aviation_industry
+		HUN_establish_the_air_force
+		HUN_indigenous_designs
+		HUN_light_fighter_effort
+		HUN_trade_deal_with_germany
+		HUN_joint_aluminum_mining_company
+		
+	}
+
+	research = {
+		armor = -100
+		cat_mobile_warfare = -1000
+		cat_grand_battle_plan = -1000
+		cat_strategic_destruction = -1000
+		cat_operational_integrity = -1000
+		synth_resources = -1000
+	}
+
+	ideas = {
+		HUN_zoltan_tildy = 100
+		free_trade = 15000
+		export_focus = 0
+		limited_exports = 0
+		closed_economy = 0
+		HUN_lajos_remenyi_schneller = 20
+		HUN_mavag = 10
+		HUN_shvoy_kalman = -100
+		HUN_gyorgy_jendrassik = 3
+		war_economy = 100
+		extensive_conscription = 10
+	}
+
+	ai_strategy = {
+	}
+
+	traits = {
+	}
+
+	# Keep small, as it is used as a factor for some things (such as research needs)
+	# Recommended around 1.0. Useful for relation between plans
+	weight = {
+		factor = 1.0
+		modifier = {
+			factor = 1.0
+		}
+	}
+
+	focus_factors = {
+		HUN_claim_transylvania = 0
+		HUN_claim_overlordship_over_slovakia = 0
+	}
+
+}
+
+
+HUN_MP_Alliance = {
+	name = "Hungarian-German Alliance"
+	desc = ""
+
+	enable = {
+		original_tag = HUN
+		OR = {
+			has_game_rule = {
+				rule = HUN_ai_behavior
+				option = HUN_MP_1
+			}
+			has_game_rule = {
+				rule = HUN_ai_behavior
+				option = HUN_MP_2
+			}
+		}
+	}
+
+	abort = {
+	}
+
+	ai_strategy = {
+		type = alliance
+		id = GER
+		value = 400
+	}
+	ai_strategy = {
+		type = prepare_for_war
+		id = ENG
+		value = 200
+	}
+	ai_strategy = {
+		type = dont_join_wars_with
+		id = ITA
+		target_country = YUG
+		value = 500
+	}
+	ai_strategy = {
+		type = dont_join_wars_with
+		id = ITA
+		target_country = GRE
+		value = 500
+	}
+}

--- a/common/ai_strategy_plans/INS_MP_plan.txt
+++ b/common/ai_strategy_plans/INS_MP_plan.txt
@@ -1,0 +1,246 @@
+INS_MP_1 = {
+	name = "Dutch-East-Indies Multiplayer 1"
+	desc = ""
+
+	enable = {
+		original_tag = INS
+		has_game_rule = {
+			rule = INS_ai_behavior
+			option = INS_MP_1
+		}
+	}
+
+	abort = {
+	}
+
+	ai_national_focuses = {
+		naval_effort
+		industrial_effort
+		construction_effort
+		construction_effort_2
+		infrastructure_effort
+		infrastructure_effort_2
+		extra_tech_slot
+		extra_tech_slot_2
+		construction_effort_3
+		political_effort
+		liberty_ethos
+		neutrality_focus
+		deterrence
+		production_effort
+		production_effort_2
+		production_effort_3
+		aviation_effort
+		why_we_fight
+		technology_sharing
+	}
+
+	research = {
+		synth_resources = -1000
+		construction_tech = 100
+		armor = -1000
+		air_equipment = -1000
+		artillery = 100
+		cat_anti_tank = -1000
+	}
+
+	ideas = {
+		free_trade = 100000
+		generic_captain_of_industry = 10
+		generic_fortification_engineer = 2
+		war_economy = 20
+		partial_economic_mobilisation = 10
+		extensive_conscription = 10
+		generic_industrial_concern = 5
+		generic_electronics_concern = 0
+		generic_tank_manufacturer = 0
+		generic_naval_manufacturer = 0
+		generic_naval_theorist = 0
+		generic_air_warfare_theorist = 0
+		generic_navy_chief_decisive_bat = 0
+		generic_navy_anti_submarine = 0
+		generic_air_close_air_sup = 0
+		generic_air_chief_all_weather = 0
+		generic_army_art = 0
+		generic_navy_fleet_log = 0
+		generic_air_air_combat_trainer = 0
+	}
+	
+		
+	ai_strategy = {
+	}
+
+	traits = {
+	}
+
+	# Keep small, as it is used as a factor for some things (such as research needs)
+	# Recommended around 1.0. Useful for relation between plans
+	weight = {
+		factor = 1.0
+		modifier = {
+			factor = 1.0
+		}
+	}
+
+	focus_factors = {
+		doctrine_effort = 0
+		mechanization_effort = 0
+		CAS_effort = 0
+		NAV_effort = 0
+		rocket_effort = 0
+		flexible_navy = 0
+		large_navy = 0
+		submarine_effort = 0
+		cruiser_effort = 0
+		nuclear_effort = 0
+	}
+}
+
+INS_MP_Infrastructure_Java = {
+	name = "Indonesia MP Build Java Infrastructure"
+	desc = ""
+
+	enable = {
+		tag = INS
+		has_game_rule = {
+			rule = INS_ai_behavior
+			option = INS_MP_1
+		}
+		335 = {
+			is_controlled_by = INS
+			infrastructure < 10
+		}
+	}
+
+	abort = {
+		335 = {
+			OR ={
+				NOT = { is_controlled_by = INS }
+				NOT = { infrastructure < 10 }
+			}
+		}
+	}
+
+	ai_strategy = {
+		type = build_building
+		id = infrastructure
+		target = 335
+		value = 10
+	}
+}
+
+INS_MP_Airbase_1 = {
+	name = "Airbase in Java"
+	desc = "Build Level 10 Airbase for Allies"
+
+	enable = {
+		original_tag = INS
+		has_game_rule = {
+			rule = INS_ai_behavior
+			option = INS_MP_1
+		}
+		335 = {
+			is_controlled_by = INS
+			air_base < 10
+			NOT = { infrastructure < 10 }
+		}
+	}
+
+	abort = {
+		335 = {
+			OR ={
+				NOT = { is_controlled_by = INS }
+				NOT = { air_base < 10 }
+			}
+		}
+	}
+
+	ai_strategy = {
+		type = build_building
+		id = air_base
+		target = 335
+		value = 10	
+	}
+}
+
+
+INS_MP_Electronics_1 = {
+	name = "Indonesia MP Electronics 2"
+	desc = ""
+
+	enable = {
+		original_tag = INS
+		has_game_rule = {
+			rule = INS_ai_behavior
+			option = INS_MP_1
+		}
+		NOT = { has_tech = mechanical_computing }
+	}
+	
+	abort = {
+		has_tech = mechanical_computing 
+	}
+
+	research = {
+		computing_tech = 100000
+	}
+}
+
+
+INS_MP_AA_Construction = {
+	name = "Indonesia MP AA Construction"
+	desc = ""
+
+	enable = {
+		original_tag = INS
+		has_game_rule = {
+			rule = INS_ai_behavior
+			option = INS_MP_1
+		}
+		has_completed_focus = deterrence
+		335 = {
+			is_controlled_by = INS
+			anti_air_building < 5
+		}
+	}
+
+	abort = {
+		335 = {
+			OR ={
+				NOT = { is_controlled_by = INS }
+				NOT = { anti_air_building < 5 }
+			}
+		}
+	}
+
+	ai_strategy = {
+		type = build_building
+		id = anti_air_building
+		target = 335
+		value = 5
+	}
+}
+
+INS_MP_Doctrine = {
+	name = "No Doctrines till 1941"
+	desc = ""
+
+	enable = {
+		original_tag = INS
+		has_game_rule = {
+			rule = INS_ai_behavior
+			option = INS_MP_1
+		}
+		NOT = { date > 1941.1.1 }
+	}
+	
+	abort = {
+		date > 1941.1.1
+	}
+
+	research = {
+		land_doctrine = -10000
+		air_doctrine = -10000
+		naval_doctrine = -10000
+	}
+}

--- a/common/ai_strategy_plans/ITA_MP_plan.txt
+++ b/common/ai_strategy_plans/ITA_MP_plan.txt
@@ -1,0 +1,248 @@
+ITA_MP_1 = {
+	name = "ITA Mulitplayer Plan 1"
+	desc = "Focus on Fighter Research"
+
+	enable = {
+		original_tag = ITA
+		has_game_rule = {
+			rule = ITA_ai_behavior
+			option = ITA_MP_1
+		}
+	}
+
+	abort = {
+	}
+
+	ai_national_focuses = {
+		ITA_ethiopian_war_logistics					#March 10 1936	
+		ITA_industrial_effort						#May 20 1936	
+		ITA_army_primacy							#July 30 1936	
+		ITA_air_innovation							#October 10 1936
+		ITA_industrial_effort_2 					#October 10 1936	
+		ITA_extra_tech_slot 						#December 20 1936	
+		ITA_italian_highways						#February 30 1937
+		ITA_victoryinETH							#May 10 1937
+		ITA_support_nationalist_spain
+		ITA_yugoslavia_friend
+		ITA_mare_nostrum
+		ITA_bulgaria_friend
+		ITA_pact_of_steel
+		ITA_albania_war_goal
+		ITA_demand_balearic_islands
+		ITA_modernized_artillery	
+		ITA_modernized_army
+		ITA_prospect_for_oil
+		ITA_libyan_infrastructure
+		ITA_bomber_effort
+		ITA_air_innovation_2
+		ITA_german_rd_treaty
+		#ITA_fortification_effort					#November 20 1939	
+		#ITA_romania_friend							#January 30 1940
+		#ITA_light_ship_effort  					#April 10 1940
+		#ITA_special_forces 						#June 20 1940	
+		#ITA_escort_effort							#August 30 1940
+		#ITA_german_rd_treaty 						#November 10 1940
+		#ITA_german_millitary_cooperation 			#January 20 1941	
+		#ITA_naval_air_effort 						#March 30 1941	
+		#ITA_atlantic_fleet 						#June 10 1941	
+		#ITA_marines_and_landing_craft 				#August 20 1941
+		#ITA_capital_ships 							#October 30 1941	
+ 		#ITA_armored_effort 						#January 10
+ 		#ITA_claims_on_france 						#March 20 1942
+ 		#ITA_sea_wolves 							#May 30 1942	
+ 		#ITA_secret_weapons 						#August 10 1942
+													#October 20 1942	
+ 		#ITA_submarine_effort 						#December 30 1942	
+ 		#ITA_libyan_refineries 						#March 10 1943
+ 													#May 20 1943	
+		 											#July 30 1943		
+	}				
+
+	research = {
+		cat_mobile_warfare = 40
+		synth_resources = -100
+		cat_grand_battle_plan = -10000
+		cat_strategic_destruction = -10000
+	}
+
+	ideas = {
+		war_economy = 1000
+		ITA_luigi_einaudi = 200
+		macchi = 150
+		danieli = 50
+		rodolfo_graziani = 0
+	}
+	
+	
+	ai_strategy = {
+		type = pp_spend_priority
+		id = general
+		value = -1000
+	}
+
+	# Keep small, as it is used as a factor for some things (such as research needs)
+	# Recommended around 1.0. Useful for relation between plans
+	weight = {
+		factor = 1.0
+		modifier = {
+			factor = 1.0
+		}
+	}
+}
+
+
+
+ITA_MP_1_Fighter1 = {
+	name = "Research Fighter 1 ASAP"
+	desc = "Let the AI of Italy research Fighter 1 as his first research"
+
+	enable = {
+		original_tag = ITA
+			has_game_rule = {
+				rule = ITA_ai_behavior
+				option = ITA_MP_1
+				}
+			}
+
+	abort = {
+		has_tech = fighter1
+	}
+
+	research = {
+		light_fighter = 10000
+	}
+
+}
+
+ITA_MP_1_Fighter2 = {
+	name = "Research Fighter 2 ASAP"
+	desc = "Let the AI of Italy research Fighter 2 as soons as it is avaible"
+
+	enable = {
+		original_tag = ITA
+		has_game_rule = {
+			rule = ITA_ai_behavior
+			option = ITA_MP_1
+		}
+		has_completed_focus = ITA_air_innovation
+		NOT = { has_tech = fighter2 }
+	}
+
+	abort = {
+		has_tech = fighter2
+	}
+
+	research = {
+		light_fighter = 10000
+	}	
+
+}
+
+ITA_MP_1_Fighter3 = {
+	name = "Research Fighter 3 ASAP"
+	desc = "Let the AI of Italy research Fighter 3 as it has Air Innovation II"
+
+	enable = {
+		original_tag = ITA
+		has_game_rule = {
+			rule = ITA_ai_behavior
+			option = ITA_MP_1
+		}
+		has_completed_focus = ITA_air_innovation_2
+		NOT = { has_tech = fighter3 }
+	}
+
+	abort = {
+		has_tech = fighter3
+	}
+
+	research = {
+		light_fighter = 100000
+	}
+
+}
+
+ITA_MP_1_NoBombers = {
+	name = "Produce no Bombers"
+	desc = ""
+
+	enable = {
+		original_tag = ITA
+		has_game_rule = {
+			rule = ITA_ai_behavior
+			option = ITA_MP_1
+		}
+	}
+	abort = {
+	}
+	
+	ai_strategy = {
+		type = equipment_production_factor
+		id = cas
+		value = -100000
+	}
+	ai_strategy = {
+		type = equipment_production_factor
+		id = tactical_bomber
+		value = -100000
+	}
+	ai_strategy = {
+		type = equipment_production_factor
+		id = strategic_bomber
+		value = -100000
+	}
+}
+
+ITA_MP_1_CivBuildup = {
+	name = "Italian Civ Buildup"
+	desc = ""
+
+	enable = {
+		original_tag = ITA
+		has_game_rule = {
+			rule = ITA_ai_behavior
+			option = ITA_MP_1
+		}
+		date < 1938.1.1
+	}
+	abort_when_not_enabled = yes
+	
+	ai_strategy = {
+		type = building_target
+		id = industrial_complex
+		value = 80
+	}
+}
+
+ITA_MP_Befriend_Axis = {
+	name = ""
+	desc = ""
+
+	enable = {
+		original_tag = ITA
+		has_game_rule = {
+			rule = ITA_ai_behavior
+			option = ITA_MP_1
+		}
+	}
+
+	abort = {
+
+	}
+
+	ai_strategy = {
+		type = befriend
+		id = GER
+		value = 200
+	}
+	ai_strategy = {
+		type = befriend
+		id = JAP
+		value = 200
+	}
+	ai_strategy = {
+		type = pp_spend_priority
+		id = relation	
+		value = -200
+	}	
+}

--- a/common/ai_strategy_plans/JAP_MP_plan.txt
+++ b/common/ai_strategy_plans/JAP_MP_plan.txt
@@ -1,0 +1,213 @@
+JAP_MP_1 = {
+	name = "JAP_MP_1"
+	desc = "RULE_OPTION_JAP_MP_1_DESC"
+
+	enable = {
+		original_tag = JAP
+		has_game_rule = {
+			rule = JAP_ai_behavior
+			option = JAP_MP_1
+		}
+	}
+	abort = {
+	}
+
+	ai_national_focuses = {
+		JAP_purge_the_kodoha_faction #March 10 1936	
+		JAP_guide_the_zaibatsus #May 20 1936	
+		JAP_national_mobilization_law #July 30 1936	
+		JAP_national_research_policy #October 10 1936	
+		JAP_nationalize_war_industry #December 20 1936	
+		#1937
+		JAP_national_defense_state #February 30 1937	
+		JAP_spiritual_mobilization #May 10 1937	
+		JAP_army_expansion_law #July 20 1937	
+		JAP_liaison_conference #September 30 1937	
+		JAP_greater_east_asian_co_prosperity_sphere #December 10 1937	
+		#1938
+		JAP_intervene_in_china #February 20 1938	
+		JAP_warrior_spirit #April 30 1938	
+		JAP_new_naval_estimates #July 10 1938	
+		JAP_small_arms_modernization #September 20 1938	
+		JAP_army_expansion 
+		JAP_fighter_modernization
+		#1939
+		JAP_agility_focus
+		JAP_carrier_warfare_experiments
+		JAP_cruiser_modernization
+		JAP_long_lance_torpedoes
+		JAP_first_air_fleet		
+		#1940
+		JAP_the_zero
+		JAP_modern_escorts
+		JAP_sign_tripartite_pact
+		JAP_strike_south_doctrine
+		JAP_non_aggression_pact_with_the_soviet_union
+		#1941
+		JAP_secure_the_philippines
+		JAP_strike_on_the_southern_resource_area
+	}
+	
+	
+
+
+
+	research = {
+		bb_tech = -500
+		cat_mobile_warfare = -1000
+		cat_grand_battle_plan = -1000
+		cat_mass_assault = -1000
+	}
+
+	ideas = {
+		JAP_mitsumasa_yonai = 1000
+		kawasaki = 40
+		hisaichi_terauchi = 30
+		mitsubishi = 50
+		JAP_chiune_sugihara = 0
+		closed_economy = 0
+	}
+
+
+	# Keep small, as it is used as a factor for some things (such as research needs)
+	# Recommended around 1.0. Useful for relation between plans
+	weight = {
+		factor = 1.0
+		modifier = {
+			factor = 1.0
+		}
+	}
+
+}
+
+JAP_MP_IgnoreSoviet = {
+	name = "IgnoreSoviet"
+	desc = ""
+
+	enable = {
+		original_tag = JAP
+		has_game_rule = {
+			rule = JAP_ai_behavior
+			option = JAP_MP_1
+		}
+		date < 1940.1.1
+	}
+
+	abort = { date > 1940.1.1
+	}
+	
+	ai_strategy = {
+		type = ignore
+		id = SOV
+		value = 1000
+	
+	}
+}
+
+JAP_MP_Conquer_Shanxi = {
+	name = ""
+	desc = ""
+
+	enable = {
+		original_tag = JAP
+		has_game_rule = {
+			rule = JAP_ai_behavior
+			option = JAP_MP_1
+		}
+		OR = {
+			NOT = { SHX =  {is_subject_of = JAP } }
+			NOT = { SHX = { is_in_faction_with = JAP } }
+		}
+	}
+
+	abort = {
+		OR = {
+			SHX =  {is_subject_of = JAP }
+			SHX = { is_in_faction_with = JAP }
+		}
+	}
+	
+	ai_strategy = {
+		type = conquer
+		id = "SHX"
+		value = 200
+	
+	}
+}
+
+JAP_MP_Conquer_China = {
+	name = ""
+	desc = ""
+
+	enable = {
+		original_tag = JAP
+		has_game_rule = {
+			rule = JAP_ai_behavior
+			option = JAP_MP_1
+		}
+		OR = {
+			NOT = { CHI =  {is_subject_of = JAP } }
+			NOT = { CHI = { is_in_faction_with = JAP } }
+		}
+	}
+
+	abort = {
+		OR = {
+			CHI =  {is_subject_of = JAP }
+			CHI = { is_in_faction_with = JAP }
+		}
+	}
+	
+	ai_strategy = {
+		type = conquer
+		id = "CHI"
+		value = 200
+	
+	}
+}
+
+JAP_MP_Befriend_Germany = {
+	name = ""
+	desc = ""
+
+	enable = {
+		original_tag = JAP
+		has_game_rule = {
+			rule = JAP_ai_behavior
+			option = JAP_MP_1
+		}
+	}
+
+	abort = {
+
+	}
+
+	ai_strategy = {
+		type = befriend
+		id = GER
+		value = 200
+	}
+}
+
+JAP_MP_Befriend_Italy = {
+	name = ""
+	desc = ""
+
+	enable = {
+		original_tag = JAP
+		has_game_rule = {
+			rule = JAP_ai_behavior
+			option = JAP_MP_1
+		}
+	}
+
+	abort = {
+
+	}
+
+	ai_strategy = {
+		type = befriend
+		id = ITA
+		value = 200
+	}
+}

--- a/common/ai_strategy_plans/MAL_MP_plan.txt
+++ b/common/ai_strategy_plans/MAL_MP_plan.txt
@@ -1,0 +1,256 @@
+MAL_MP_1 = {
+	name = "Malaya Multiplayer 1"
+	desc = ""
+
+	enable = {
+		original_tag = MAL
+		has_game_rule = {
+			rule = MAL_ai_behavior
+			option = MAL_MP_1
+		}
+	}
+
+	abort = {
+	}
+
+	ai_national_focuses = {
+		industrial_effort
+		construction_effort
+		construction_effort_2
+		production_effort
+		production_effort_2
+		production_effort_3
+		army_effort
+		motorization_effort
+		mechanization_effort
+		armor_effort
+		infrastructure_effort
+		infrastructure_effort_2
+		extra_tech_slot
+		extra_tech_slot_2
+		construction_effort_3
+		political_effort
+		liberty_ethos
+		neutrality_focus
+		deterrence
+		secret_weapons
+		naval_effort
+		aviation_effort
+	}
+
+	research = {
+		synth_resources = -1000
+		construction_tech = 1000
+		land_doctrine = -10000
+		air_doctrine = -10000
+		naval_doctrine = -10000
+	}
+
+	ideas = {
+		free_trade = 100000
+		export_focus = 0
+		tank_manufacturer = 100
+		generic_captain_of_industry = 10
+		war_economy = 20
+		partial_economic_mobilisation = 10
+		extensive_conscription = 10
+		generic_industrial_concern = 5
+	}
+	
+		
+	ai_strategy = {
+	}
+
+	traits = {
+	}
+
+	# Keep small, as it is used as a factor for some things (such as research needs)
+	# Recommended around 1.0. Useful for relation between plans
+	weight = {
+		factor = 1.0
+		modifier = {
+			factor = 1.0
+		}
+	}
+
+	focus_factors = {
+		equipment_effort = 0
+		motorization_effort = 0
+		mechanization_effort = 0
+		CAS_effort = 0
+		rocket_effort = 0
+		large_navy = 0
+		flexible_navy = 0
+		nuclear_effort = 0
+	}
+}
+
+MAL_MP_Doctrine = {
+	name = "Malayan Multiplayer Plan Doctinres"
+	desc = ""
+
+	enable = {
+		original_tag = MAL
+		has_game_rule = {
+			rule = MAL_ai_behavior
+			option = MAL_MP_1
+		}
+		NOT = { date > 1940.1.1 }
+	}
+	
+	abort = {
+		date > 1940.1.1
+	}
+
+	research = {
+		land_doctrine = -10000
+		air_doctrine = -10000
+		naval_doctrine = -10000
+	}
+}
+
+MAL_MP_Airbase_1 = {
+	name = "Airbase in Malay"
+	desc = "Build Level 10 Airbase for UK"
+
+	enable = {
+		original_tag = MAL
+		has_game_rule = {
+			rule = MAL_ai_behavior
+			option = MAL_MP_1
+		}
+		336 = {
+			is_controlled_by = MAL
+			air_base < 10
+		}
+	}
+
+	abort = {
+		336 = {
+			OR ={
+				NOT = { is_controlled_by = MAL }
+				NOT = { air_base < 10 }
+			}
+		}
+	}
+
+	ai_strategy = {
+		type = build_building
+		id = air_base
+		target = 336
+		value = 100
+	}
+}
+
+
+MAL_MP_Electronics_1 = {
+	name = "Malayan Multiplayer Plan Electronics 2"
+	desc = ""
+
+	enable = {
+		original_tag = MAL
+		has_game_rule = {
+			rule = MAL_ai_behavior
+			option = MAL_MP_1
+		}
+		NOT = { has_tech = mechanical_computing }
+	}
+	
+	abort = {
+		has_tech = mechanical_computing 
+	}
+
+	research = {
+		computing_tech = 100000
+	}
+}
+
+MAL_MP_Radar_Research = {
+	name = ""
+	desc = ""
+
+	enable = {
+		original_tag = MAL
+		has_game_rule = {
+			rule = MAL_ai_behavior
+			option = MAL_MP_1
+		}
+		has_completed_focus = extra_tech_slot
+	}
+
+	abort = {
+		has_tech = advanced_centimetric_radar
+	}
+
+	research = {
+		radar_tech = 50000
+	}
+}
+
+MAL_MP_Radar_Construction = {
+	name = ""
+	desc = ""
+
+	enable = {
+		original_tag = MAL
+		has_game_rule = {
+			rule = MAL_ai_behavior
+			option = MAL_MP_1
+		}
+		has_tech = radio_detection
+		336 = {
+			is_controlled_by = MAL
+			radar_station < 6
+		}
+	}
+
+	abort = {
+		336 = {
+			OR ={
+				NOT = { is_controlled_by = MAL }
+				NOT = { radar_station < 6 }
+			}
+		}
+	}
+
+	ai_strategy = {
+		type = build_building
+		id = radar_station
+		target = 336
+		value = 100
+	}
+}
+
+MAL_MP_AA_Construction = {
+	name = ""
+	desc = ""
+
+	enable = {
+		original_tag = MAL
+		has_game_rule = {
+			rule = MAL_ai_behavior
+			option = MAL_MP_1
+		}
+		has_completed_focus = deterrence
+		336 = {
+			is_controlled_by = MAL
+			anti_air_building < 5
+		}
+	}
+
+	abort = {
+		336 = {
+			OR ={
+				NOT = { is_controlled_by = MAL }
+				NOT = { anti_air_building < 5 }
+			}
+		}
+	}
+
+	ai_strategy = {
+		type = build_building
+		id = anti_air_building
+		target = 336
+		value = 100
+	}
+}

--- a/common/ai_strategy_plans/MAN_MP_plan.txt
+++ b/common/ai_strategy_plans/MAN_MP_plan.txt
@@ -1,0 +1,244 @@
+MAN_MP_1 = {
+	name = "Manchukuo Multiplayer Plan"
+	desc = "No Alliance with Kwantung"
+
+	enable = {
+		original_tag = MAN
+		has_game_rule = {
+			rule = MAN_ai_behavior
+			option = MAN_MP_1
+		}
+	}
+
+	abort = {
+	}
+
+	ai_national_focuses = {
+		MAN_pacify_the_countryside
+		MAN_army_modernization
+		MAN_mukden_military_academy
+		MAN_law_university
+		MAN_research_and_education_department
+		MAN_obedience
+		MAN_first_five_year_plan
+		MAN_invite_japanese_investors
+		MAN_expand_the_railways
+		MAN_social_research_unit
+		MAN_invite_japanese_settlers
+		CHI_invite_foreign_investors
+		MAN_hoankyoku
+		MAN_develop_aluminum_sources
+		MAN_expand_showa_steel_works
+		MAN_trade_delegation
+		MAN_expand_the_textile_industry
+		MAN_mukden_arsenal
+		MAN_collective_farms
+		MAN_mamc
+	}
+
+	focus_factors = {
+		MAN_alliance_with_the_kwantung_army = 0
+		MAN_chinese_leadership = 0
+		MAN_vassalize_mengukuo = 0
+		MAN_national_cooperation_government = 0
+		MAN_the_two_emperors = 0
+		CHI_one_china_policy = 0
+	}
+
+	research = {
+		excavation_tech = 100
+		synth_resources = -1000
+		air_doctrine = -1000
+		naval_doctrine = -1000
+		air_equipment = -1000
+		naval_equipment = -1000
+	}
+
+	ideas = {
+	MAN_songgotu_zhanshan = 100
+	MAN_hung_zhehuang = 3
+	MAN_kyoiji_tomonaga = 2
+	}
+
+	# Keep small, as it is used as a factor for some things (such as research needs)
+	# Recommended around 1.0. Useful for relation between plans
+	weight = {
+		factor = 1.0
+		modifier = {
+			factor = 1.0
+		}
+	}
+
+}
+
+MAN_MP_2 = {
+	name = "Manchukuo Multiplayer Plan"
+	desc = "Vassalize Menguko"
+
+	enable = {
+		original_tag = MAN
+			has_game_rule = {
+				rule = MAN_ai_behavior
+				option = MAN_MP_2
+				}
+			}
+
+	abort = {
+	}
+
+	ai_national_focuses = {
+		MAN_pacify_the_countryside
+		MAN_army_modernization
+		MAN_mukden_military_academy
+		MAN_law_university
+		MAN_research_and_education_department
+		MAN_obedience
+		MAN_first_five_year_plan
+		MAN_invite_japanese_investors
+		MAN_alliance_with_the_kwantung_army
+		MAN_chinese_leadership
+		MAN_vassalize_mengukuo
+		MAN_expand_the_railways
+		MAN_social_research_unit
+		MAN_invite_japanese_settlers
+		CHI_invite_foreign_investors
+		MAN_hoankyoku
+		MAN_develop_aluminum_sources
+		MAN_expand_showa_steel_works
+		MAN_trade_delegation
+		MAN_expand_the_textile_industry
+		MAN_mukden_arsenal
+		MAN_collective_farms
+		MAN_mamc
+	}
+
+	focus_factors = {
+		MAN_national_cooperation_government = 0
+		MAN_the_two_emperors = 0
+		CHI_one_china_policy = 0
+	}
+
+	research = {
+		excavation_tech = 100
+		synth_resources = -1000
+		air_doctrine = -1000
+		naval_doctrine = -1000
+		air_equipment = -1000
+		naval_equipment = -1000
+	}
+
+	ideas = {
+	MAN_songgotu_zhanshan = 100
+	MAN_hung_zhehuang = 3
+	MAN_kyoiji_tomonaga = 2
+	}
+
+	# Keep small, as it is used as a factor for some things (such as research needs)
+	# Recommended around 1.0. Useful for relation between plans
+	weight = {
+		factor = 1.0
+		modifier = {
+			factor = 1.0
+		}
+	}
+
+}
+
+MAN_MP_Industry_1 = {
+	name = ""
+	desc = ""
+
+	enable = {
+		original_tag = MAN
+		OR = {
+			has_game_rule = {
+				rule = MAN_ai_behavior
+				option = MAN_MP_1
+			}
+			has_game_rule = {
+				rule = MAN_ai_behavior
+				option = MAN_MP_2
+			}
+		}
+		has_completed_focus = MAN_social_research_unit
+		NOT = {
+			has_tech = excavation3
+		}
+	}
+
+	abort = {
+		is_researching_technology = excavation3
+	}
+
+	research = {
+		construction_tech = 10000
+	}
+}
+
+
+MAN_MP_Industry_2 = {
+	name = ""
+	desc = ""
+
+	enable = {
+		original_tag = MAN
+		OR = {
+			has_game_rule = {
+				rule = MAN_ai_behavior
+				option = MAN_MP_1
+			}
+			has_game_rule = {
+				rule = MAN_ai_behavior
+				option = MAN_MP_2
+			}
+		}
+		has_completed_focus = MAN_trade_delegation
+	}
+
+	abort = {
+		is_researching_technology = excavation4
+	}
+
+	research = {
+		construction_tech = 10000
+	}
+}
+
+MAN_MP_Infrastructure = {
+	name = "Mandschuko Oil in Daqing"
+	desc = "Build Level 10 Infrastructure for Oil"
+
+	enable = {
+		original_tag = MAN
+		OR = {
+			has_game_rule = {
+				rule = MAN_ai_behavior
+				option = MAN_MP_1
+			}
+			has_game_rule = {
+				rule = MAN_ai_behavior
+				option = MAN_MP_2
+			}
+		}
+		714 = {
+			is_controlled_by = MAN
+			infrastructure < 10
+		}
+	}
+
+	abort = {
+		714 = {
+			OR ={
+				NOT = { is_controlled_by = MAN }
+				NOT = { infrastructure < 10 }
+			}
+		}
+	}
+
+	ai_strategy = {
+		type = build_building
+		id = infrastructure
+		target = 714
+		value = 100
+	}
+}

--- a/common/ai_strategy_plans/MEN_MP_plan.txt
+++ b/common/ai_strategy_plans/MEN_MP_plan.txt
@@ -1,0 +1,57 @@
+MEN_MP_1 = {
+	name = "Mengokou Multiplayer 1"
+	desc = "Focus Industry"
+
+	enable = {
+		original_tag = MEN
+		has_game_rule = {
+			rule = MEN_ai_behavior
+			option = MEN_MP_1
+			}
+	}
+
+	abort = {
+		
+	}
+
+	ai_national_focuses = {
+		industrial_effort
+		construction_effort
+		construction_effort_2
+		infrastructure_effort
+		construction_effort_3
+		infrastructure_effort_2
+		production_effort
+		production_effort_2
+		production_effort_3
+		extra_tech_slot
+	}
+
+	research = {
+		construction_tech = 1000
+	}
+
+	ideas = {
+	}
+	
+		
+	ai_strategy = {
+	}	
+
+	traits = {
+	}
+
+	# Keep small, as it is used as a factor for some things (such as research needs)
+	# Recommended around 1.0. Useful for relation between plans
+	weight = {
+		factor = 1.0
+		modifier = {
+			factor = 1.0
+		}
+	}
+
+	focus_factors = {
+		
+	}
+
+}

--- a/common/ai_strategy_plans/MON_MP_plan.txt
+++ b/common/ai_strategy_plans/MON_MP_plan.txt
@@ -1,0 +1,233 @@
+MON_MP_1 = {
+	name = "Mongolia Multiplayer 1"
+	desc = ""
+
+	enable = {
+		original_tag = MON
+		has_game_rule = {
+			rule = MON_ai_behavior
+			option = MON_MP_1
+		}
+	}
+
+	abort = {
+	}
+
+	ai_national_focuses = {
+		political_effort
+		industrial_effort
+		construction_effort
+		construction_effort_2
+		infrastructure_effort
+		infrastructure_effort_2
+		extra_tech_slot
+		extra_tech_slot_2
+		production_effort
+		production_effort_2
+		production_effort_3
+		construction_effort_3
+		aviation_effort
+		fighter_focus
+		army_effort
+		doctrine_effort
+		doctrine_effort_2
+	}
+
+	research = {
+		synth_resources = -1000
+	}
+
+	ideas = {
+		war_economy = 100
+		free_trade = 5000
+		extensive_conscription = 10
+	}
+	
+		
+	ai_strategy = {
+	}
+
+	traits = {
+	}
+
+	# Keep small, as it is used as a factor for some things (such as research needs)
+	# Recommended around 1.0. Useful for relation between plans
+	weight = {
+		factor = 1.0
+		modifier = {
+			factor = 1.0
+		}
+	}
+
+	focus_factors = {
+	}
+}
+
+MON_MP_Electronics_1 = {
+	name = "Mongolian Multiplayer Plan Electronics 1"
+	desc = ""
+
+	enable = {
+		original_tag = MON
+		has_game_rule = {
+			rule = MON_ai_behavior
+			option = MON_MP_1
+		}
+		NOT = { has_tech = electronic_mechanical_engineering }
+	}
+	
+	abort = {
+		has_tech = electronic_mechanical_engineering 
+	}
+
+	research = {
+		electronics = 10000
+		industry = -5000
+	}
+}
+
+MON_MP_Electronics_2 = {
+	name = "Mongolian Multiplayer Plan Electronics 2"
+	desc = ""
+
+	enable = {
+		original_tag = MON
+		has_game_rule = {
+			rule = MON_ai_behavior
+			option = MON_MP_1
+		}
+		NOT = { has_tech = mechanical_computing }
+	}
+	
+	abort = {
+		has_tech = mechanical_computing 
+	}
+
+	research = {
+		computing_tech = 100000
+		industry = -5000
+	}
+}
+
+MON_MP_Radio = {
+	name = ""
+	desc = ""
+
+	enable = {
+		original_tag = MON
+		has_game_rule = {
+			rule = MON_ai_behavior
+			option = MON_MP_1
+		}
+		has_tech = mechanical_computing
+		not = { has_tech = radio }
+	}
+
+	abort = {
+		has_tech = radio
+	}
+
+	research = {
+		electronics = 200
+	}
+}
+
+MON_MP_Radar_Research = {
+	name = ""
+	desc = ""
+
+	enable = {
+		original_tag = MON
+		has_game_rule = {
+			rule = MON_ai_behavior
+			option = MON_MP_1
+		}
+		has_completed_focus = extra_tech_slot
+	}
+
+	abort = {
+	}
+
+	research = {
+		radar_tech = 600
+	}
+}
+
+MON_MP_Radar_Construction = {
+	name = ""
+	desc = ""
+
+	enable = {
+		original_tag = MON
+		has_game_rule = {
+			rule = MON_ai_behavior
+			option = MON_MP_1
+		}
+		has_tech = radio_detection
+		724 = {
+			is_controlled_by = MON
+			radar_station < 6
+		}
+	}
+
+	abort = {
+		724 = {
+			OR ={
+				NOT = { is_controlled_by = MON }
+				NOT = { radar_station < 6 }
+			}
+		}
+	}
+
+	ai_strategy = {
+		type = build_building
+		id = radar_station
+		target = 724
+		value = 100
+	}
+}
+
+No_PP_For_Relation = {
+	name = ""
+	desc = ""
+
+	enable = {
+		tag = MON
+		has_game_rule = {
+			rule = CAN_ai_behavior
+			option = CAN_MP_1
+		}
+	}
+
+	abort = {
+	}
+
+	ai_strategy = {
+		type = pp_spend_priority
+		id = relation	
+		value = -200
+	}	
+}
+
+Soviet_Do_Befriend = {
+	name = ""
+	desc = ""
+
+	enable = {
+		tag = MON
+		country_exists = JAP
+		has_game_rule = {
+			rule = MON_ai_behavior
+			option = MON_MP_1
+		}
+	}
+
+	abort = {
+	}
+
+	ai_strategy = {
+		type = befriend
+		id = SOV			
+		value = 200
+	}	
+}

--- a/common/ai_strategy_plans/NZL_MP_plan.txt
+++ b/common/ai_strategy_plans/NZL_MP_plan.txt
@@ -1,4 +1,4 @@
-NZL_historical = {
+NZL_MP_plan = {
 	name = "New Zealand Multiplayer Plan 1"
 	desc = ""
 

--- a/common/ai_strategy_plans/NZL_MP_plan.txt
+++ b/common/ai_strategy_plans/NZL_MP_plan.txt
@@ -1,0 +1,81 @@
+NZL_historical = {
+	name = "New Zealand Multiplayer Plan 1"
+	desc = ""
+
+	enable = {
+		original_tag = NZL
+		has_dlc = "Together for Victory"
+			has_game_rule = {
+				rule = NZL_ai_behavior
+				option = NZL_MP_1
+			}
+
+	}
+
+	abort = {
+	}
+
+	ai_national_focuses = {
+		NZL_the_first_labor_government
+		NZL_strengthen_the_commonwealth
+		NZL_2nzef
+		NZL_arrest_pacifist_leaders
+		NZL_technology_sharing_with_britain
+		#1937
+		NZL_national_roads_board
+		NZL_wairarapa_sheep_farms
+		NZL_new_zealand_steel
+		NZL_bureau_of_industry
+		NZL_department_of_scientific_and_industrial_research
+		#1938
+		NZL_industrial_conscription
+		NZL_army_reforms
+		NZL_charlton_automatic_rifle
+		NZL_domestic_arms_industry
+		NZL_think_big
+		#1939
+		NZL_expand_the_university_of_auckland
+		NZL_form_the_rnzaf
+		NZL_expand_the_nzpaf
+		NZL_form_the_rnzn
+		NZL_fighter_focus
+		#1940
+		NZL_modern_fighters
+		NZL_ratana_alliance
+		NZL_social_security_act
+		NZL_maori_affairs_act
+		NZL_the_manpower_act
+		NZL_taranaki_oil
+	}
+
+	research = {
+		industry = 20.0
+		infantry_tech = 15.0
+		artillery = 8.0
+		support_tech = 6.5
+	}
+
+	ideas = {
+		
+	}
+
+	traits = {
+		captain_of_industry = 5
+		war_industrialist = 5
+	}
+
+	# Keep small, as it is used as a factor for some things (such as research needs)
+	# Recommended around 1.0. Useful for relation between plans
+	weight = {
+		factor = 1.0
+		modifier = {
+			factor = 1.0
+		}
+	}
+
+	focus_factors = {
+		
+	}
+
+}
+

--- a/common/ai_strategy_plans/POL_MP_plan.txt
+++ b/common/ai_strategy_plans/POL_MP_plan.txt
@@ -1,0 +1,499 @@
+POL_MP_1 = {
+	name = "POL Multiplayer Plan 1"
+	desc = ""
+
+	enable = {
+		original_tag = POL
+		has_game_rule = {
+			rule = POL_ai_behavior
+			option = POL_MP_1
+		}
+		is_subject = no
+	}
+
+	abort = {
+		is_subject = yes
+	}
+
+	ai_national_focuses = {
+		#1936
+		POL_strengthen_the_polish_state
+		POL_defensive_focus
+		POL_the_four_year_plan
+		POL_national_defence_fund
+		POL_warsaw_main_railway_station
+		#1937
+		POL_invest_in_the_old_polish_region
+		POL_additional_research_slot1
+		POL_develop_upper_silesia	
+		POL_polish_militarism		
+		POL_central_region_strategy
+		#1938
+		POL_expansion_of_new_towns
+		POL_start_central_industrial_region
+		POL_fill_the_railways_gaps
+		POL_expand_central_industrial_region
+		POL_prepare_for_the_next_war
+		#1939
+		POL_develop_polish_ship_building
+		POL_the_defence_of_poland
+		POL_romanian_bridgehead_strategy
+		POL_hel_fortified_area
+		POL_artillery_modernisation
+		POL_silesia_fortified_area
+		
+	}
+
+	research = {
+		synth_resources = -1000
+	}
+
+	ideas = {
+		civilian_economy = 0
+		low_economic_mobilisation = 100
+		partial_economic_mobilisation = 200
+		war_economy = 300
+		limited_conscription = 1
+		POL_tomislaw_lupaszko = 10
+		POL_jozef_haller = 40
+		POL_roman_dmowski = 0
+		POL_stanislaw_radkiewicz = 0
+		POL_eugeniusz_kwiatkowiski = 0
+		POL_jozef_beck = 0
+		POL_wladyslaw_kalkus = 0
+		POL_jozef_zajac = 0
+		POL_lrl = 0
+		POL_ava = 0
+	}
+
+	traits = {
+	}
+
+	ai_strategy = {
+	}
+
+	
+
+	# Keep small, as it is used as a factor for some things (such as research needs)
+	# Recommended around 1.0. Useful for relation between plans
+	weight = {
+		factor = 1.0
+		modifier = {
+			factor = 1.0
+		}
+	}
+}
+
+POL_MP_Template = {
+	name = "Templates"
+	desc = ""
+
+	enable = {
+		tag = POL
+		has_game_rule = {
+			rule = POL_ai_behavior
+			option = POL_MP_1
+		}
+	}
+
+	abort = {
+	}
+
+	ai_strategy = {
+		type = template_prio
+		id = infantry
+		value = 40
+	}
+	ai_strategy = {
+		type = template_prio
+		id = garrison
+		value = -40
+	}
+	ai_strategy = {
+		type = prepare_for_war
+		id = GER	
+		value = 200
+	}
+}
+
+POL_More_Mils = {
+	name = "Only construct Mils after 1937"
+	desc = ""
+
+	enable = {
+		tag = POL
+		has_game_rule = {
+			rule = POL_ai_behavior
+			option = POL_MP_1
+		}
+		date > 1937.1.1
+	}
+
+	abort = {
+	}
+
+	ai_strategy = {
+		type = added_military_to_civilian_factory_ratio
+		value = 100
+	}	
+}
+
+No_PP_For_Relation = {
+	name = "No PP for Relation"
+	desc = ""
+
+	enable = {
+		tag = POL
+		has_game_rule = {
+			rule = POL_ai_behavior
+			option = POL_MP_1
+		}
+	}
+
+	abort = {
+	}
+
+	ai_strategy = {
+		type = pp_spend_priority
+		id = relation	
+		value = -200
+	}	
+}
+
+POL_MP_Radio = {
+	name = "Research radio"
+	desc = ""
+
+	enable = {
+		tag = POL
+		has_game_rule = {
+			rule = POL_ai_behavior
+			option = POL_MP_1
+		}
+		has_tech = mechanical_computing
+		has_completed_focus = POL_additional_research_slot1
+		NOT = {
+			OR = {
+				has_tech = radio
+				is_researching_technology = radio
+			}
+		}
+	}
+
+	abort = {
+		OR = {
+			has_tech = radio
+			is_researching_technology = radio
+		}
+	}
+
+	research = {
+		electronics = 100
+	}
+}
+
+POL_MP_Arty = {
+	name = "Research Arty"
+	desc = ""
+
+	enable = {
+		tag = POL
+		has_game_rule = {
+			rule = POL_ai_behavior
+			option = POL_MP_1
+		}
+		date > 1938.1.1
+		has_completed_focus = POL_additional_research_slot1
+		NOT = {
+			OR = {
+				has_tech = artillery1
+				is_researching_technology = artillery1
+			}
+		}
+	}
+
+	abort = {
+		OR = {
+			has_tech = artillery1
+			is_researching_technology = artillery1
+		}
+	}
+
+	research = {
+		artillery = 10000
+		cat_anti_tank = -20000
+	}
+}
+
+POL_MP_AA_Production = {
+	name = "Produce Anti-Air Guns"
+	desc = ""
+
+	enable = {
+		tag = POL
+		has_game_rule = {
+			rule = POL_ai_behavior
+			option = POL_MP_1
+		}
+		has_tech = antiair1
+	}
+
+	abort = {
+	}
+
+	ai_strategy = {
+		type = equipment_production_factor
+		id = anti_air
+		value = 200
+	}
+	ai_strategy = {
+		type = equipment_production_factor
+		id = infantry
+		value = -1000
+	}
+
+}
+
+POL_MP_ForceUnits = {
+	name = "Force Build Units"
+	desc = ""
+
+	enable = {
+		tag = POL
+		has_game_rule = {
+			rule = POL_ai_behavior
+			option = POL_MP_1
+		}
+		date > 1938.6.1
+		has_manpower > 200000
+		GER = { has_capitulated = no }
+	}
+
+	abort = {
+		OR = {
+			POL = { has_manpower < 200000 }
+			GER = { has_capitulated = yes }
+		}
+	}
+
+	ai_strategy = {
+		type = force_build_armies
+		value = 100
+	}
+}
+
+POL_MP_No_Generals = {
+	name = "No Generals"
+	desc = ""
+
+	enable = {
+		tag = POL
+		has_game_rule = {
+			rule = POL_ai_behavior
+			option = POL_MP_1
+		}
+		date < 1939.1.1
+	}
+
+	abort = {
+		date > 1939.1.1
+	}
+
+	ai_strategy = {
+		type = pp_spend_priority
+		id = general
+		value = -1000
+	}
+}
+
+POL_MP_No_Admirals = {
+	name = "No Admirals"
+	desc = ""
+
+	enable = {
+		tag = POL
+		has_game_rule = {
+			rule = POL_ai_behavior
+			option = POL_MP_1
+		}
+		date < 1940.1.1
+	}
+
+	abort = {
+		date > 1940.1.1
+	}
+
+	ai_strategy = {
+		type = pp_spend_priority
+		id = admiral
+		value = -1000
+	}
+}
+
+POL_MP_1_AirUnits = {
+	name = "No Air of Naval Units"
+	desc = ""
+
+	enable = {
+		original_tag = POL
+		has_game_rule = {
+			rule = POL_ai_behavior
+			option = POL_MP_1
+		}
+	}
+	abort = {
+	}
+	
+	research = {
+		air_equipment = -1000
+		air_doctrine = -1000
+		naval_equipment = -1000
+		naval_doctrine = -1000
+	}
+	
+	ai_strategy = {
+		type = unit_ratio
+		id = fighter
+		value = -1000000
+	}
+	ai_strategy = {
+		type = equipment_production_factor
+		id = fighter
+		value = -1000000
+	}
+	ai_strategy = {
+		type = equipment_variant_production_factor
+		id = fighter_equipment
+		value = -1000000
+	}
+	ai_strategy = {
+		type = equipment_production_factor
+		id = cas
+		value = -10000
+	}
+	ai_strategy = {
+		type = equipment_production_factor
+		id = naval_bomber
+		value = -10000
+	}
+	ai_strategy = {
+		type = equipment_production_factor
+		id = tactical_bomber
+		value = -10000
+	}
+	ai_strategy = {
+		type = equipment_production_factor
+		id = strategic_bomber
+		value = -10000
+	}
+	ai_strategy = {
+		type = unit_ratio
+		id = screen_ship
+		value = -1000
+	}
+}
+
+POL_MP_Antagonize = {
+	name = "Antagonize Axis and befriend Soviet/India"
+	desc = ""
+
+	enable = {
+		tag = POL
+		has_game_rule = {
+			rule = POL_ai_behavior
+			option = POL_MP_1
+		}
+	}
+
+	abort = {
+	}
+	
+	ai_strategy = {
+		type = antagonize
+		id = JAP
+		value = 200
+	}
+	ai_strategy = {
+		type = antagonize
+		id = ROM
+		value = 200
+	}
+	ai_strategy = {
+		type = antagonize
+		id = HUN
+		value = 200
+	}
+	ai_strategy = {
+		type = antagonize
+		id = BUL
+		value = 200
+	}
+	ai_strategy = {
+		type = befriend
+		id = SOV
+		value = 200
+	}
+	ai_strategy = {
+		type = befriend
+		id = RAJ
+		value = 200
+	}
+}
+
+MP_Spy_Defense = {
+	name = "Spy Defense"
+	desc = ""
+
+	enable = {
+		tag = POL
+		has_game_rule = {
+			rule = POL_ai_behavior
+			option = POL_MP_1
+		}
+	}
+
+	abort = {
+	}
+
+	ai_strategy = {
+		type = intelligence_agency_usable_factories
+		value = 5
+	}
+	ai_strategy = {
+		type = intelligence_agency_usable_factories
+		value = 5
+	}
+	ai_strategy = {
+		type = agency_ai_base_num_factories_factor
+		value = -100    # -100% on the define
+	}
+	ai_strategy = {
+		type = agency_ai_per_upgrade_factories_factor
+		value = -100    # -100% on the define
+	}
+	ai_strategy = {
+		type = operative_mission
+		mission = counter_intelligence
+		value = 100
+	}
+	ai_strategy = {
+		type = operative_mission
+		mission = build_intel_network
+		value = -100
+	}
+	ai_strategy = {
+		type = operative_mission
+		mission = quiet_network
+		value = -100
+	}
+	ai_strategy = {
+		type = operative_mission
+		mission = root_out_resistance
+		value = -100
+	}
+	ai_strategy = {
+		type = operative_mission
+		mission = control_trade
+		value = -100
+	}
+}

--- a/common/ai_strategy_plans/RAJ_MP_plan.txt
+++ b/common/ai_strategy_plans/RAJ_MP_plan.txt
@@ -1,0 +1,474 @@
+RAJ_MP_1 = {
+	name = "Indian Mulitplayer Plan 1"
+	desc = ""
+
+	enable = {
+		original_tag = RAJ
+		has_dlc = "Together for Victory"
+		has_game_rule = {
+			rule = RAJ_ai_behavior
+			option = RAJ_MP_1
+		}
+	}
+	abort = {
+	}
+
+	ai_national_focuses = {
+		RAJ_provincial_elections
+		RAJ_indian_national_congress
+		RAJ_cripps_mission
+		RAJ_two_nation_theory
+		RAJ_quit_india_movement				
+		RAJ_great_indian_peninsula_railway
+		RAJ_industrial_expansion
+		RAJ_tata_steel										
+		RAJ_assam_oil										
+		RAJ_indian_institute_of_science
+		RAJ_east_india_railways								
+		RAJ_integrate_princely_railways						
+		RAJ_clamp_down_on_corruption
+		RAJ_princely_state_donations
+		RAJ_imperial_service_troops
+		RAJ_lessons_of_the_great_war
+		RAJ_indianisation_of_army
+		RAJ_british_army_support
+		RAJ_chindits
+		RAJ_ishapore_arsenal
+		RAJ_strengthen_ties_with_british_investors
+		RAJ_british_rail_investors							
+		RAJ_british_arms_investors	
+		RAJ_the_bangalore_torpedo
+		RAJ_royal_indian_artillery
+		RAJ_revive_the_screw_guns
+		RAJ_modernizing_army
+		RAJ_an_indian_sandhurst
+		RAJ_indian_gentlemen_officers
+		RAJ_indian_defense_research
+		RAJ_lions_of_the_great_war
+		RAJ_indian_gurkhas
+		RAJ_jungle_training
+		RAJ_vickers_berthier_gun							
+		RAJ_institute_of_fundamental_research
+		RAJ_expand_mazagon_dock											
+		RAJ_found_scindia_shipyard
+		RAJ_british_pilot_training
+		RAJ_expand_air_bases
+		RAJ_army_motorization
+		RAJ_indian_armor		
+		RAJ_red_eagle_division								
+	}
+
+	research = {
+		industry = 20.0
+		infantry_tech = 15.0
+		artillery = 8.0
+		support_tech = 6.5
+		cat_mass_assault = 100
+		air_equipment = -1000
+		air_doctrine = -1000
+		naval_equipment = -1000
+		naval_doctrine = -1000
+	}
+
+	ideas = {
+		civilian_economy = 0
+		low_economic_mobilisation = 100
+		partial_economic_mobilisation = 200
+		war_economy = 300
+		RAJ_john_edward_golightly = 100
+		free_trade = 20000
+		RAJ_john_mathai = 30
+		RAJ_chakravarti_rajagopalachari = 20
+		RAJ_anyang_bhula = 0
+		RAJ_bahadur_jayla_of_khoch_bahur = 0
+		RAJ_homi_j_bhabha = 0
+		RAJ_bruce_w_mcpherson = 0
+		RAJ_subroto_mukherjee = 0
+		RAJ_ravindra_darshan_singh = 0
+		RAJ_louis_mountbatten = 0
+		RAJ_william_e_parry = 0
+		RAJ_bhaskar_soman = 0
+		RAJ_ram_dass_katari = 0
+		RAJ_arjan_singh_vibhusan = 0
+		RAJ_aspy_merwan_engineer = 0
+		RAJ_mehar_singh = 0
+		RAJ_w_h_gould_bradford = 0
+		mazagon_dock_limited = 0
+		garden_reach_shipbuilders = 0
+		scindia_shipyard = 0
+		generic_tank_manufacturer = 0
+		hindustan_aircraft = 0
+		generic_light_aircraft_manufacturer = 0
+		generic_medium_aircraft_manufacturer = 0
+		generic_heavy_aircraft_manufacturer = 0
+		generic_naval_aircraft_manufacturer = 0
+		generic_industrial_concern = 10
+		generic_electronics_concern = 0
+		generic_motorized_equipment_manufacturer = 0
+	}
+
+	traits = {
+	}
+
+	# Keep small, as it is used as a factor for some things (such as research needs)
+	# Recommended around 1.0. Useful for relation between plans
+	weight = {
+		factor = 1.0
+		modifier = {
+			factor = 1.0
+		}
+	}
+
+	focus_factors = {
+		RAJ_royal_indian_navy = 0
+		RAJ_fighter_effort = 0
+		RAJ_air_support_effort = 0
+	}
+
+}
+
+No_PP_For_Relation = {
+	name = ""
+	desc = ""
+
+	enable = {
+		tag = RAJ
+		has_game_rule = {
+			rule = RAJ_ai_behavior
+			option = RAJ_MP_1
+		}
+	}
+
+	abort = {
+	}
+
+	ai_strategy = {
+		type = pp_spend_priority
+		id = relation	
+		value = -200
+	}	
+}
+
+MP_No_Generals = {
+	name = ""
+	desc = ""
+
+	enable = {
+		tag = RAJ
+		has_game_rule = {
+			rule = RAJ_ai_behavior
+			option = RAJ_MP_1
+		}
+		date < 1940.1.1
+	}
+
+	abort = {
+		date > 1940.1.1
+	}
+
+	ai_strategy = {
+		type = pp_spend_priority
+		id = general
+		value = -1000
+	}
+	ai_strategy = {
+		type = pp_spend_priority
+		id = admiral
+		value = -1000
+	}
+}
+
+MP_1_No_AirUnits = {
+	name = "Indian Mulitplayer Plan 1"
+	desc = ""
+
+	enable = {
+		original_tag = RAJ
+		has_game_rule = {
+			rule = RAJ_ai_behavior
+			option = RAJ_MP_1
+		}
+	}
+	abort = {
+	}
+	
+	ai_strategy = {
+		type = unit_ratio
+		id = fighter
+		value = -1000000
+	}
+	ai_strategy = {
+		type = equipment_production_factor
+		id = fighter
+		value = -1000000
+	}
+	ai_strategy = {
+		type = equipment_variant_production_factor
+		id = fighter_equipment
+		value = -1000000
+	}
+	ai_strategy = {
+		type = equipment_production_factor
+		id = cas
+		value = -10000
+	}
+	ai_strategy = {
+		type = equipment_production_factor
+		id = naval_bomber
+		value = -10000
+	}
+	ai_strategy = {
+		type = equipment_production_factor
+		id = tactical_bomber
+		value = -10000
+	}
+	ai_strategy = {
+		type = equipment_production_factor
+		id = strategic_bomber
+		value = -10000
+	}
+}
+
+RAJ_MP_Infrastructure_1 = {
+	name = "RAJ Infrastructure"
+	desc = "Build Level 10 for Supply and Buildspeed"
+
+	enable = {
+		tag = RAJ
+		has_game_rule = {
+			rule = RAJ_ai_behavior
+			option = RAJ_MP_1
+		}
+		439 = {
+			is_controlled_by = RAJ
+			infrastructure < 10
+		}
+	}
+
+	abort = {
+		439 = {
+			OR ={
+				NOT = { is_controlled_by = RAJ }
+				NOT = { infrastructure < 10 }
+			}
+		}
+	}
+
+	ai_strategy = {
+		type = build_building
+		id = infrastructure
+		target = 439
+		value = 10
+	}
+}
+
+RAJ_MP_Infrastructure_2 = {
+	name = "RAJ Infrastructure"
+	desc = "Build Level 10 for Supply and Buildspeed"
+
+	enable = {
+		tag = RAJ
+		has_game_rule = {
+			rule = RAJ_ai_behavior
+			option = RAJ_MP_1
+		}
+		429 = {
+			is_controlled_by = RAJ
+			infrastructure < 10
+		}
+		OR = {
+			439 = {
+				is_controlled_by = RAJ
+				NOT = { infrastructure < 10 }
+			}
+			AND = {
+				439 = {
+					is_controlled_by = RAJ
+					infrastructure < 10
+				}
+				num_of_civilian_factories_available_for_projects > 15
+			}
+		}
+	}
+
+	abort = {
+		OR = {
+			429 = {
+				OR ={
+					NOT = { is_controlled_by = RAJ }
+					NOT = { infrastructure < 10 }
+				}
+			}
+			AND = {
+				num_of_civilian_factories_available_for_projects < 15
+				439 = {
+					is_controlled_by = RAJ
+					infrastructure < 10
+				}
+			}
+		}
+	}
+
+	ai_strategy = {
+		type = build_building
+		id = infrastructure
+		target = 429
+		value = 10
+	}
+}
+
+RAJ_MP_Civilian_1 = {
+	name = ""
+	desc = ""
+
+	enable = {
+		tag = RAJ
+		has_game_rule = {
+			rule = RAJ_ai_behavior
+			option = RAJ_MP_1
+		}
+		date < 1939.1.1
+		429 = {
+			NOT { infrastructure < 10 }
+		}
+		439 = {
+			is_controlled_by = RAJ
+			NOT = { infrastructure < 10 }
+			free_building_slots = {
+				building = industrial_complex
+				size > 0
+				include_locked = no
+			}
+		}
+	}
+
+	abort = {
+		OR = {
+			date > 1939.1.1
+			439 = {
+				OR ={
+					NOT = { is_controlled_by = RAJ }
+					free_building_slots = {
+						building = industrial_complex
+						size < 1
+						include_locked = no
+					}
+				}
+			}
+		}
+	}
+
+	ai_strategy = {
+		type = build_building
+		id = industrial_complex
+		target = 439
+		value = 6
+	}
+}
+
+RAJ_MP_Civilian_2 = {
+	name = ""
+	desc = ""
+
+	enable = {
+		tag = RAJ
+		has_game_rule = {
+			rule = RAJ_ai_behavior
+			option = RAJ_MP_1
+		}
+		429 = {
+			is_controlled_by = RAJ
+			NOT = { infrastructure < 10 }
+			free_building_slots = {
+				building = industrial_complex
+				size > 0
+				include_locked = no
+			}
+		}
+		439 = {
+			is_controlled_by = RAJ
+			NOT = { infrastructure < 10 }
+		}
+		date < 1939.1.1
+	}
+
+	abort = {
+		OR = {
+			date > 1939.1.1
+			429 = {
+				OR ={
+					NOT = { is_controlled_by = RAJ }
+					free_building_slots = {
+						building = industrial_complex
+						size < 1
+						include_locked = no
+					}
+				}
+			}
+		}
+	}
+
+	ai_strategy = {
+		type = build_building
+		id = industrial_complex
+		target = 429
+		value = 5
+	}
+}
+
+RAJ_MP_Civilian = {
+	name = ""
+	desc = ""
+
+	enable = {
+		tag = RAJ
+		has_game_rule = {
+			rule = RAJ_ai_behavior
+			option = RAJ_MP_1
+		}
+		date > 1937.1.1
+		date < 1939.1.1
+	}
+
+	abort = {
+		OR = {
+			date > 1939.1.1
+		}
+	}
+
+	ai_strategy = {
+		type = building_target
+		id = industrial_complex
+		value = 50
+	}
+}
+
+RAJ_MP_Airbase_1 = {
+	name = "RAJ Westbengal Airbase"
+	desc = "Build Level 10 Airbase"
+
+	enable = {
+		tag = RAJ
+		has_game_rule = {
+			rule = RAJ_ai_behavior
+			option = RAJ_MP_1
+		}
+		has_war = yes
+	}
+
+	abort = {
+		431 = {
+			OR ={
+				NOT = { is_controlled_by = RAJ }
+				NOT = { air_base < 10 }
+			}
+		}
+	}
+
+	ai_strategy = {
+		type = build_building
+		id = air_base
+		target = 431
+		value = 10
+	}
+}

--- a/common/ai_strategy_plans/ROM_MP_plan.txt
+++ b/common/ai_strategy_plans/ROM_MP_plan.txt
@@ -1,0 +1,191 @@
+ROM_MP_1 = {
+	name = "Romanian Multiplayer 1"
+	desc = ""
+
+	enable = {
+		original_tag = ROM
+		has_dlc = "Death or Dishonor"
+		has_game_rule = {
+			rule = ROM_ai_behavior
+			option = ROM_MP_1
+				}
+			}
+
+	abort = {
+		
+	}
+
+	ai_national_focuses = {
+		ROM_institute_royal_dictatorship
+		ROM_revise_the_constitution
+		ROM_the_royal_foundation
+		ROM_king_michaels_coup
+		ROM_flexible_foreign_policy
+		ROM_appoint_german_friendly_government
+		ROM_preserve_greater_romania
+		ROM_civil_works
+		ROM_agrarian_reform
+		ROM_danubian_transport_network
+		ROM_malaxa
+		ROM_hunedoara_steel_works
+		ROM_a_deal_with_the_devil
+		ROM_form_peasant_militias
+		ROM_invest_in_the_iar
+		ROM_expand_ploiesti_oil_production
+		ROM_expand_the_university_of_bucharest
+		ROM_expand_the_air_force
+		ROM_trade_treaty_with_germany
+		ROM_invite_german_advisors
+		ROM_join_axis
+		ROM_german_romanian_oil_exploitation_company
+		#ROM_army_maneuvers
+		#ROM_expand_the_air_force
+		#ROM_local_development
+		#ROM_air_superiority
+		#ROM_expand_the_galati_shipyards
+		#ROM_iar_80
+		#ROM_cas
+		#ROM_royal_guards_divisions
+		#ROM_the_zb_53
+		#ROM_vanatori_de_munte
+		#ROM_the_armored_division
+		#ROM_army_war_college
+		#ROM_acquire_modern_tanks
+		#ROM_artillery_modernization
+		#ROM_mobile_tank_destroyers
+		#ROM_mountain_artillery
+		#ROM_coastal_defense_navy
+		#ROM_modern_destroyers
+		#ROM_the_maresal
+	}
+
+	research = {
+	}
+
+	ideas = {
+		ROM_gheorghe_argeseanu = 100
+		ROM_nicolae_malaxa = 15
+		ROM_ROMLOC = 10
+		ROM_mihail_sturdza = 2
+		ROM_armand_calinescu = -1000
+		ROM_iuliu_maniu = -1000
+		partial_economic_mobilisation = 1000
+		war_economy = 2000
+		free_trade = 10000
+		export_focus = 0
+		limited_exports = 0
+		closed_economy = 0
+	}
+		
+	ai_strategy = {
+	}
+
+	traits = {
+		captain_of_industry = 5
+		war_industrialist = 5
+	}
+
+	# Keep small, as it is used as a factor for some things (such as research needs)
+	# Recommended around 1.0. Useful for relation between plans
+	weight = {
+		factor = 1.0
+		modifier = {
+			factor = 1.0
+		}
+	}
+
+	focus_factors = {
+		
+	}
+
+}
+
+ROM_MP_1_Infrastructure = {
+	name = "Infrastructure 10"
+	desc = "Build Level 10 Infrastructure for Oil"
+
+	enable = {
+		original_tag = ROM
+		has_game_rule = {
+			rule = ROM_ai_behavior
+			option = ROM_MP_1
+				}
+			46 = {
+		is_controlled_by = ROM
+		infrastructure < 10
+			}
+	}
+
+	abort = {
+		46 = {
+			OR ={
+				NOT = { is_controlled_by = ROM }
+				NOT = { infrastructure < 10 }
+			}
+		}
+	}
+
+	ai_strategy = {
+		type = build_building
+		id = infrastructure
+		target = 46
+		value = 3
+	}
+}
+
+ROM_MP_1_Alliance = {
+	name = "Romanian-German Alliance"
+	desc = ""
+
+	enable = {
+		original_tag = ROM
+		has_game_rule = {
+			rule = ROM_ai_behavior
+			option = ROM_MP_1
+		}
+	}
+
+	abort = {
+	}
+
+	ai_strategy = {
+		type = alliance
+		id = GER
+		value = 200
+	}
+	ai_strategy = {
+		type = prepare_for_war
+		id = ENG
+		value = 200
+	}
+}
+
+GER_MP_1_NoWar = {
+	name = "Dont join Italian wars"
+	desc = ""
+
+	enable = {
+		original_tag = ROM
+		has_game_rule = {
+			rule = ROM_ai_behavior
+			option = ROM_MP_1
+		}
+	}
+
+	abort = {
+
+	}
+
+	ai_strategy = {
+		type = dont_join_wars_with
+		id = ITA
+		target_country = GRE
+		value = 500
+	}
+	ai_strategy = {
+		type = dont_join_wars_with
+		id = ITA
+		target_country = YUG
+		value = 500
+	}
+}

--- a/common/ai_strategy_plans/SAF_MP_plan.txt
+++ b/common/ai_strategy_plans/SAF_MP_plan.txt
@@ -1,5 +1,5 @@
 SAF_MP_1 = {
-	name = "South African historical plan"
+	name = "South African Mulitplayer plan"
 	desc = ""
 
 	enable = {
@@ -42,7 +42,7 @@ SAF_MP_1 = {
 		SAF_suppress_the_stormjaers
 		SAF_desert_equipment
 		SAF_special_service_battalion
-		SAF_secure_the_cape_sea_routes
+		SAF_secure_the_cape_sea_route
 		SAF_seaward_defence_force
 		SAF_q_services_corps
 		SAF_sa_engineer_corps
@@ -272,29 +272,6 @@ SAF_MP_1_NAV2 = {
 
 	abort = {
 		has_tech = naval_bomber2
-	}
-
-	research = {
-		naval_bomber = 10000
-	}	
-}
-
-SAF_MP_1_NAV3 = {
-	name = "Research Naval Bomber 3"
-	desc = ""
-
-	enable = {
-		tag = SAF
-		has_game_rule = {
-			rule = SAF_ai_behavior
-			option = SAF_MP_1
-		}
-		has_completed_focus = SAF_secure_the_cape_sea_routesm
-		NOT = { has_tech = naval_bomber3 }
-	}
-
-	abort = {
-		has_tech = naval_bomber3
 	}
 
 	research = {

--- a/common/ai_strategy_plans/SAF_MP_plan.txt
+++ b/common/ai_strategy_plans/SAF_MP_plan.txt
@@ -1,0 +1,323 @@
+SAF_MP_1 = {
+	name = "South African historical plan"
+	desc = ""
+
+	enable = {
+		original_tag = SAF
+		has_dlc = "Together for Victory"
+		has_game_rule = {
+			rule = SAF_ai_behavior
+			option = SAF_MP_1
+		}
+
+	}
+
+	abort = {
+		
+	}
+
+	ai_national_focuses = {
+		SAF_war_measures_act
+		SAF_support_the_policy_of_appeasement
+		SAF_south_african_railways
+		SAF_expand_the_mining_industry
+		SAF_infrastructure_effort
+		SAF_south_african_steel
+		SAF_expand_the_rand_mines
+		SAF_fund_the_university_of_south_africa
+		SAF_armament_effort
+		SAF_pretoria_arms
+		SAF_police_windhoek
+		SAF_voortrekker_monument
+		SAF_csir
+		SAF_emergency_workers
+		SAF_commit_to_the_five_year_plan
+		SAF_replace_the_blenheim
+		SAF_cape_garrison_artillery
+		SAF_reconstitute_the_cape_corps
+		SAF_expand_the_cape_corps	
+		SAF_native_laws_amendment_act	
+		SAF_work_for_all_poor
+		SAF_joint_air_training_scheme
+		SAF_suppress_the_stormjaers
+		SAF_desert_equipment
+		SAF_special_service_battalion
+		SAF_secure_the_cape_sea_routes
+		SAF_seaward_defence_force
+		SAF_q_services_corps
+		SAF_sa_engineer_corps
+		SAF_south_african_special_forces
+	}
+
+	focus_factors = {
+		SAF_perfect_the_cab_rank_technique = 0
+		SAF_anti_submarine_tactics = 0
+		SAF_submarine_warfare = 0
+	}
+
+	research = {
+		industry = 20.0
+		infantry_tech = 15.0
+		artillery = 8.0
+		support_tech = 6.5
+		cat_mobile_warfare = -10000
+		cat_superior_firepower = -10000
+		cat_grand_battle_plan = -10000
+		cat_mass_assault = 10
+		air_doctrine = -1000
+		naval_equipment = -1000
+		naval_doctrine = -1000
+	}
+
+	ideas = {
+		SAF_e_g_jansen = 1000
+		SAF_nicolaas_havenga = 10
+		SAF_d_f_malan = 0
+		free_trade = 10000
+		export_focus = 0
+		SAF_pierre_van_ryneveld = 0
+		generic_light_aircraft_manufacturer = 0
+		generic_medium_aircraft_manufacturer = 0
+		generic_heavy_aircraft_manufacturer = 0
+		generic_electronics_concern = 0
+		generic_motorized_equipment_manufacturer = 0
+		generic_artillery_manufacturer = 0
+		SAF_c_de_weenburg_du_toit = 0
+		SAF_pierre_van_ryneveld = 0
+	}
+
+	traits = {
+		captain_of_industry = 5
+		war_industrialist = 5
+	}
+
+	# Keep small, as it is used as a factor for some things (such as research needs)
+	# Recommended around 1.0. Useful for relation between plans
+	weight = {
+		factor = 1.0
+		modifier = {
+			factor = 1.0
+		}
+	}
+}
+
+SAF_MP_Advisors = {
+	name = "Blocked Advisors till capitulated or Mid-1940"
+	desc = ""
+
+	enable = {
+		tag = SAF
+		has_game_rule = {
+			rule = SAF_ai_behavior
+			option = SAF_MP_1
+		}
+		OR = {
+			FRA = { has_capitulated = no }
+			date < 1940.1.1
+		}
+	}
+
+	abort = {
+		OR = {
+			FRA = { has_capitulated = yes }
+			date > 1940.1.1
+		}
+	}
+
+	ideas = {
+		iscor = 0
+		generic_naval_manufacturer = 0
+		generic_air_close_air_sup = 0
+		generic_air_chief_all_weather = 0
+		SAF_robert_palmer = 0
+		SAF_marinus_van_osterkamp = 0
+		SAF_jeannot_de_la_tourier = 0
+		SAF_adolf_malan = 0
+		SAF_james_mitchell_baker = 0
+		SAF_leonard_beyers = 0
+	}
+	
+	ai_strategy = {
+		type = pp_spend_priority
+		id = general
+		value = -1000
+	}
+
+	ai_strategy = {
+		type = pp_spend_priority
+		id = admiral
+		value = -1000
+	}
+}
+
+SAF_MP_Infrastructure_1 = {
+	name = "SAF Infrastructure"
+	desc = "Build Level 10 for Buildspeed"
+
+	enable = {
+		tag = SAF
+		has_game_rule = {
+			rule = SAF_ai_behavior
+			option = SAF_MP_1
+		}
+		275 = {
+			is_controlled_by = SAF
+			infrastructure < 10
+		}
+	}
+
+	abort = {
+		275 = {
+			OR ={
+				NOT = { is_controlled_by = SAF }
+				NOT = { infrastructure < 10 }
+			}
+		}
+	}
+
+	ai_strategy = {
+		type = build_building
+		id = infrastructure
+		target = 275
+		value = 5
+	}
+}
+
+SAF_MP_No_MIL = {
+	name = "No Mil"
+	desc = "Build Level 10 for Buildspeed"
+
+	enable = {
+		tag = SAF
+		has_game_rule = {
+			rule = SAF_ai_behavior
+			option = SAF_MP_1
+		}
+		date < 1938.1.1
+	}
+
+	abort = {
+		OR = {
+			date > 1938.1.1
+			SAF = { arms_factory > 1 }
+		}
+	}
+
+	ai_strategy = {
+		type = building_target
+		id = arms_factory
+		value = 1
+	}
+}
+
+SAF_MP_1_AirUnits = {
+	name = "SAF No Air"
+	desc = ""
+
+	enable = {
+		tag = SAF
+		has_game_rule = {
+			rule = SAF_ai_behavior
+			option = SAF_MP_1
+		}
+	}
+	abort = {
+	}
+	
+	ai_strategy = {
+		type = unit_ratio
+		id = fighter
+		value = -1000000
+	}
+	ai_strategy = {
+		type = equipment_production_factor
+		id = fighter
+		value = -1000000
+	}
+	ai_strategy = {
+		type = equipment_variant_production_factor
+		id = fighter_equipment
+		value = -1000000
+	}
+	ai_strategy = {
+		type = equipment_production_factor
+		id = cas
+		value = -10000
+	}
+	ai_strategy = {
+		type = equipment_production_factor
+		id = tactical_bomber
+		value = -10000
+	}
+	ai_strategy = {
+		type = equipment_production_factor
+		id = strategic_bomber
+		value = -10000
+	}
+}
+
+SAF_MP_1_NAV2 = {
+	name = "Research Naval Bomber 2"
+	desc = ""
+
+	enable = {
+		tag = SAF
+		has_game_rule = {
+			rule = SAF_ai_behavior
+			option = SAF_MP_1
+		}
+		has_completed_focus = SAF_replace_the_blenheim
+		NOT = { has_tech = naval_bomber2 }
+	}
+
+	abort = {
+		has_tech = naval_bomber2
+	}
+
+	research = {
+		naval_bomber = 10000
+	}	
+}
+
+SAF_MP_1_NAV3 = {
+	name = "Research Naval Bomber 3"
+	desc = ""
+
+	enable = {
+		tag = SAF
+		has_game_rule = {
+			rule = SAF_ai_behavior
+			option = SAF_MP_1
+		}
+		has_completed_focus = SAF_secure_the_cape_sea_routesm
+		NOT = { has_tech = naval_bomber3 }
+	}
+
+	abort = {
+		has_tech = naval_bomber3
+	}
+
+	research = {
+		naval_bomber = 10000
+	}	
+}
+
+SAF_MP_AirDoctrine = {
+	name = "Air Doctrine Research"
+	desc = ""
+
+	enable = {
+		tag = SAF
+		has_game_rule = {
+			rule = SAF_ai_behavior
+			option = SAF_MP_1
+		}
+	has_tech = naval_strike_tactics
+	}
+	abort = { 
+	}
+	
+	research = {
+		cat_strategic_destruction = -10000
+	}
+}

--- a/common/ai_strategy_plans/SIA_MP_plan.txt
+++ b/common/ai_strategy_plans/SIA_MP_plan.txt
@@ -1,0 +1,804 @@
+SIA_MP_1 = {
+	name = "Siam Multiplayer 1"
+	desc = ""
+
+	enable = {
+		tag = SIA
+		has_game_rule = {
+			rule = SIA_ai_behavior
+			option = SIA_MP_1
+		}
+	}
+
+	abort = {
+	}
+
+	ai_national_focuses = {
+		industrial_effort
+		construction_effort
+		construction_effort_2
+		infrastructure_effort
+		infrastructure_effort_2
+		extra_tech_slot
+		extra_tech_slot_2
+		construction_effort_3
+		political_effort
+		collectivist_ethos
+		nationalism_focus
+		aviation_effort_2
+		militarism
+		production_effort
+		production_effort_2
+		production_effort_3
+		military_youth
+		paramilitarism
+		ideological_fanaticism
+		technology_sharing
+		naval_effort
+		aviation_effort
+		fighter_focus
+	}
+
+	research = {
+		synth_resources = -1000
+		construction_tech = 1000
+		air_doctrine = -1000
+		naval_doctrine = -1000
+	}
+
+	ideas = {
+		SIA_kuang_abhayavongsa = 1000
+		SIA_phot_bhahalyodin = -1000
+		partial_economic_mobilisation = 50
+		war_economy = 100
+		generic_light_aircraft_manufacturer = 500
+		export_focus = 0
+		free_trade = 1000
+		generic_electronics_concern = 0
+		extensive_conscription = 10
+		SIA_manphya_khanphialong = 0
+		SIA_sawat_phutianands = 0
+	}
+	
+		
+	ai_strategy = {
+	}
+
+	traits = {
+	}
+
+	# Keep small, as it is used as a factor for some things (such as research needs)
+	# Recommended around 1.0. Useful for relation between plans
+	weight = {
+		factor = 1.0
+		modifier = {
+			factor = 1.0
+		}
+	}
+
+	focus_factors = {
+		equipment_effort = 0
+		motorization_effort = 0
+		mechanization_effort = 0
+		CAS_effort = 0
+		rocket_effort = 0
+		large_navy = 0
+		submarine_effort = 0
+		cruiser_effort = 0
+		nuclear_effort = 0
+	}
+}
+
+SIA_MP_Military = {
+	name = "Siamese Multiplayer Plan Military"
+	desc = ""
+
+	enable = {
+		tag = SIA
+		has_game_rule = {
+			rule = SIA_ai_behavior
+			option = SIA_MP_1
+		}
+		NOT = { date > 1941.1.1 }
+	}
+	
+	abort = {
+		date > 1941.1.1
+	}
+
+	research = {
+		land_doctrine = -10000
+	}
+	ideas = {
+		SIA_luang_phibunsongkhram = 0
+		SIA_phraya_chitnasongkhla = 0
+		SIA_phra_vechayanrangsarit = 0
+		SIA_phraya_chalermarkiart = 0
+		SIA_phraya_wichcitcholathai = 0
+		SIA_thawon_thamrongnawasawat = 0
+		SIA_tianliang_huntrakool = 0
+		SIA_sindhu_kamalanavin = 0
+		SIA_luang_sinthusongkhramchai = 0
+		SIA_phraya_thayarnpikart = 0
+		SIA_pridi_phanomyong = 0
+		SIA_phraya_preechacholayudha = 0
+		tank_manufacturer = 0
+		naval_manufacturer = 0
+		generic_motorized_equipment_manufacturer = 0
+		generic_artillery_manufacturer = 0
+	}
+	
+	ai_strategy = {
+		type = pp_spend_priority
+		id = general
+		value = -1000
+	}
+	ai_strategy = {
+		type = pp_spend_priority
+		id = admiral
+		value = -1000
+	}
+}
+
+SIA_MP_No_Mil_1 = {
+	name = ""
+	desc = ""
+
+	enable = {
+		tag = SIA
+		has_game_rule = {
+			rule = SIA_ai_behavior
+			option = SIA_MP_1
+		}
+		NOT = { has_completed_focus = production_effort}
+	}
+
+	abort = {
+		has_completed_focus = production_effort 
+	}
+
+	ai_strategy = {
+		type = building_target
+		id = arms_factory
+		value = 1
+	}
+}
+
+SIA_MP_No_Mil_2 = {
+	name = ""
+	desc = ""
+
+	enable = {
+		tag = SIA
+		has_game_rule = {
+			rule = SIA_ai_behavior
+			option = SIA_MP_1
+		}
+		has_completed_focus = production_effort
+		NOT = { has_completed_focus = production_effort_2}
+	}
+
+	abort = {
+		has_completed_focus = production_effort_2
+	}
+
+	ai_strategy = {
+		type = building_target
+		id = arms_factory
+		value = 2
+	}
+}
+
+SIA_MP_No_Mil_3 = {
+	name = ""
+	desc = ""
+
+	enable = {
+		tag = SIA
+		has_game_rule = {
+			rule = SIA_ai_behavior
+			option = SIA_MP_1
+		}
+		has_completed_focus = production_effort_2
+		NOT = { has_completed_focus = production_effort_3}
+	}
+
+	abort = {
+		has_completed_focus = production_effort_3
+	}
+
+	ai_strategy = {
+		type = building_target
+		id = arms_factory
+		value = 3
+	}
+}
+
+SIA_MP_No_Mil_4 = {
+	name = ""
+	desc = ""
+
+	enable = {
+		tag = SIA
+		has_game_rule = {
+			rule = SIA_ai_behavior
+			option = SIA_MP_1
+		}
+		has_completed_focus = production_effort_3
+	}
+
+	abort = {
+		date > 1942.6.1
+	}
+
+	ai_strategy = {
+		type = building_target
+		id = arms_factory
+		value = 4
+	}
+}
+
+SIA_MP_Infrastructure_1 = {
+	name = "Siam Rubber in Northern Malay"
+	desc = "Build Level 10 Infrastructure for Rubber"
+
+	enable = {
+		tag = SIA
+		has_game_rule = {
+			rule = SIA_ai_behavior
+			option = SIA_MP_1
+		}
+		724 = {
+			is_controlled_by = SIA
+			infrastructure < 10
+		}
+	}
+
+	abort = {
+		724 = {
+			OR ={
+				NOT = { is_controlled_by = SIA }
+				NOT = { infrastructure < 10 }
+			}
+		}
+	}
+
+	ai_strategy = {
+		type = build_building
+		id = infrastructure
+		target = 724
+		value = 10
+	}
+}
+
+SIA_MP_Infrastructure_2 = {
+	name = "Siam Rubber in Siam"
+	desc = "Build Level 10 Infrastructure for Rubber and Supply"
+
+	enable = {
+		tag = SIA
+		has_game_rule = {
+			rule = SIA_ai_behavior
+			option = SIA_MP_1
+		}
+		724 = {
+			is_controlled_by = SIA
+			NOT = { infrastructure < 7 }
+		}
+		289 = {
+			is_controlled_by = SIA
+			infrastructure < 10
+		}
+	}
+
+	abort = {
+		289 = {
+			OR ={
+				NOT = { is_controlled_by = SIA }
+				NOT = { infrastructure < 10 }
+			}
+		}
+	}
+
+	ai_strategy = {
+		type = build_building
+		id = infrastructure
+		target = 289
+		value = 10
+	}
+}
+
+SIA_MP_Airbase_1 = {
+	name = "Airbase in Northern Malay"
+	desc = "Build Level 10 Airbase for Japan"
+
+	enable = {
+		tag = SIA
+		has_game_rule = {
+			rule = SIA_ai_behavior
+			option = SIA_MP_1
+		}
+		724 = {
+			is_controlled_by = SIA
+			NOT = { infrastructure < 10 }
+			air_base < 10
+		}
+		289 = {
+			is_controlled_by = SIA
+			NOT = { infrastructure < 10 }
+		}
+	}
+
+	abort = {
+		724 = {
+			OR ={
+				NOT = { is_controlled_by = SIA }
+				NOT = { air_base < 10 }
+			}
+		}
+	}
+
+	ai_strategy = {
+		type = build_building
+		id = air_base
+		target = 724
+		value = 10
+	}
+}
+
+SIA_MP_Airbase_2 = {
+	name = "Airbase in Siam"
+	desc = "Build Level 10 Airbase for Japan"
+
+	enable = {
+		tag = SIA
+		has_game_rule = {
+			rule = SIA_ai_behavior
+			option = SIA_MP_1
+		}
+		724 = {
+			is_controlled_by = SIA
+			NOT = {	infrastructure < 10 }
+			NOT = { air_base < 10 }
+		}
+		289 = {
+			is_controlled_by = SIA
+			NOT = { infrastructure < 10	}
+			air_base < 8
+		}
+	}
+
+	abort = {
+		289 = {
+			OR ={
+				NOT = { is_controlled_by = SIA }
+				NOT = { air_base < 8 }
+			}
+		}
+	}
+
+	ai_strategy = {
+		type = build_building
+		id = air_base
+		target = 289
+		value = 10
+	}
+}
+
+SIA_MP_Infrastructure_3 = {
+	name = ""
+	desc = "Build Level 7 Infrastructure in Laos for Supply"
+
+	enable = {
+		tag = SIA
+		has_game_rule = {
+			rule = SIA_ai_behavior
+			option = SIA_MP_1
+		}
+		670 = {
+			is_controlled_by = SIA
+			infrastructure < 7
+		}
+		724 = {
+			is_controlled_by = SIA
+			NOT = { infrastructure < 10 }
+			NOT = { air_base < 10 }
+		}
+		289 = {
+			is_controlled_by = SIA
+			NOT = { infrastructure < 10 }
+		}
+	}
+
+	abort = {
+		670 = {
+			OR ={
+				NOT = { is_controlled_by = SIA }
+				NOT = { infrastructure < 7 }
+			}
+		}
+	}
+
+	ai_strategy = {
+		type = build_building
+		id = infrastructure
+		target = 670
+		value = 5
+	}
+}
+
+SIA_MP_Electronics_1 = {
+	name = "Siam MP Electronics 1"
+	desc = "research electronic_mechanical_engineering"
+
+	enable = {
+		tag = SIA
+		has_game_rule = {
+			rule = SIA_ai_behavior
+			option = SIA_MP_1
+		}
+		NOT = { has_tech = electronic_mechanical_engineering }
+	}
+	
+	abort = {
+		has_tech = electronic_mechanical_engineering 
+	}
+
+	research = {
+		electronics = 10000
+		industry = -5000
+	}
+}
+
+SIA_MP_Electronics_2 = {
+	name = "Siam MP Electronics 2"
+	desc = "research mechanical_computing"
+
+	enable = {
+		tag = SIA
+		has_game_rule = {
+			rule = SIA_ai_behavior
+			option = SIA_MP_1
+		}
+		NOT = { has_tech = mechanical_computing }
+	}
+	
+	abort = {
+		has_tech = mechanical_computing 
+	}
+
+	research = {
+		computing_tech = 100000
+		industry = -5000
+	}
+}
+
+SIA_MP_Radio = {
+	name = "Siam MP Radio"
+	desc = ""
+
+	enable = {
+		tag = SIA
+		has_game_rule = {
+			rule = SIA_ai_behavior
+			option = SIA_MP_1
+		}
+		has_tech = mechanical_computing
+		NOT = {
+			OR = {
+				has_tech = radio
+				is_researching_technology = radio
+			}
+		}
+	}
+
+	abort = {
+		OR = {
+			has_tech = radio
+			is_researching_technology = radio
+		}
+	}
+
+	research = {
+		electronics = 1000
+		industry = -1000
+	}
+}
+
+SIA_MP_Radar_Research_1 = {
+	name = "Siam MP Radio 1"
+	desc = ""
+
+	enable = {
+		tag = SIA
+		has_game_rule = {
+			rule = SIA_ai_behavior
+			option = SIA_MP_1
+		}
+		has_completed_focus = extra_tech_slot
+		NOT = { has_completed_focus = technology_sharing }
+	}
+
+	abort = {
+		has_completed_focus = technology_sharing
+	}
+
+	research = {
+		radar_tech = 10000
+		industry = -100
+	}
+}
+
+SIA_MP_Radar_Research_2 = {
+	name = "Siam MP Radio 2"
+	desc = ""
+
+	enable = {
+		tag = SIA
+		has_game_rule = {
+			rule = SIA_ai_behavior
+			option = SIA_MP_1
+		}
+		has_completed_focus = extra_tech_slot
+		has_completed_focus = technology_sharing
+		NOT = { has_tech = advanced_centimetric_radar }
+	}
+
+	abort = {
+		has_tech = advanced_centimetric_radar
+	}
+
+	research = {
+		radar_tech = 50000
+	}
+}
+
+SIA_MP_Radar_Construction = {
+	name = "Siam MP Build Radio"
+	desc = ""
+
+	enable = {
+		tag = SIA
+		has_game_rule = {
+			rule = SIA_ai_behavior
+			option = SIA_MP_1
+		}
+		NOT = { has_war_with = ENG }
+		has_tech = improved_decimetric_radar
+		724 = {
+			is_controlled_by = SIA
+			radar_station < 6
+		}
+	}
+
+	abort = {
+		has_war_with = ENG
+		724 = {
+			OR ={
+				NOT = { is_controlled_by = SIA }
+				NOT = { radar_station < 6 }
+			}
+		}
+	}
+
+	ai_strategy = {
+		type = build_building
+		id = radar_station
+		target = 724
+		value = 6
+	}
+}
+
+SIA_MP_AA_1 = {
+	name = "Siam MP Build AA 1"
+	desc = ""
+
+	enable = {
+		tag = SIA
+		has_game_rule = {
+			rule = SIA_ai_behavior
+			option = SIA_MP_1
+		}
+		724 = {
+			is_controlled_by = SIA
+			anti_air_building < 5
+			NOT = {	infrastructure < 10 }
+			NOT = { air_base < 10 }
+		}
+		289 = {
+			is_controlled_by = SIA
+			NOT = { infrastructure < 10	}
+			NOT = { air_base < 10 }
+		}
+	}
+
+	abort = {
+		724 = {
+			OR ={
+				NOT = { is_controlled_by = SIA }
+				NOT = { anti_air_building < 5 }
+			}
+		}
+	}
+
+	ai_strategy = {
+		type = build_building
+		id = anti_air_building
+		target = 724
+		value = 5
+	}
+}
+
+SIA_MP_AA_2 = {
+	name = "Siam MP Build AA 2"
+	desc = ""
+
+	enable = {
+		tag = SIA
+		has_game_rule = {
+			rule = SIA_ai_behavior
+			option = SIA_MP_1
+		}
+		724 = {
+			is_controlled_by = SIA
+			NOT = { anti_air_building < 5 }
+			NOT = {	infrastructure < 10 }
+			NOT = { air_base < 10 }
+		}
+		289 = {
+			is_controlled_by = SIA
+			anti_air_building < 5
+			NOT = { infrastructure < 10	}
+			NOT = { air_base < 10 }
+		}
+	}
+
+	abort = {
+		289 = {
+			OR ={
+				NOT = { is_controlled_by = SIA }
+				NOT = { anti_air_building < 5 }
+			}
+		}
+	}
+
+	ai_strategy = {
+		type = build_building
+		id = anti_air_building
+		target = 289
+		value = 5
+	}
+}
+
+SIA_MP_Civ = {
+	name = "Siam Build Civ"
+	desc = ""
+
+	enable = {
+		tag = SIA
+		has_game_rule = {
+			rule = SIA_ai_behavior
+			option = SIA_MP_1
+		}
+		724 = {
+			is_controlled_by = SIA
+			NOT = { anti_air_building < 5 }
+			NOT = {	infrastructure < 10 }
+			NOT = { air_base < 10 }
+		}
+		289 = {
+			is_controlled_by = SIA
+			NOT = { anti_air_building < 5 }
+			NOT = { infrastructure < 10	}
+			NOT = { air_base < 10 }
+		}
+	}
+
+	abort = {
+	}
+
+	ai_strategy = {
+		type = building_target
+		id = industrial_complex
+		value = 20
+	}
+}
+
+Japan_Do_Ally = {
+	name = "Alliance and Befriend Japan"
+	desc = ""
+
+	enable = {
+		tag = SIA
+		country_exists = JAP
+		has_game_rule = {
+			rule = SIA_ai_behavior
+			option = SIA_MP_1
+		}
+	}
+
+	abort = {
+	}
+
+	ai_strategy = {
+		type = alliance
+		id = "JAP"			
+		value = 200
+	}
+	ai_strategy = {
+		type = befriend
+		id = JAP			
+		value = 200
+	}
+	ai_strategy = {
+		type = alliance
+		id = "GER"			
+		value = -200
+	}
+}
+
+Do_Befriend_But_No_PP = {
+	name = ""
+	desc = ""
+
+	enable = {
+		tag = SIA
+		has_game_rule = {
+			rule = SIA_ai_behavior
+			option = SIA_MP_1
+		}
+	}
+
+	abort = {
+	}
+
+	ai_strategy = {
+		type = pp_spend_priority
+		id = relation	
+		value = -200
+	}	
+}
+
+SIA_MP_1_NoScreen = {
+	name = ""
+	desc = ""
+
+	enable = {
+		tag = SIA
+		has_game_rule = {
+			rule = SIA_ai_behavior
+			option = SIA_MP_1
+		}
+	}
+	abort = {
+	}
+	
+	ai_strategy = {
+		type = equipment_production_factor
+		id = screen_ship
+		value = -100
+	
+	}
+}
+
+SIA_MP_1_NoCAS = {
+	name = ""
+	desc = ""
+
+	enable = {
+		tag = SIA
+		has_game_rule = {
+			rule = SIA_ai_behavior
+			option = SIA_MP_1
+		}
+	}
+	abort = {
+	}
+	
+	ai_strategy = {
+		type = equipment_production_factor
+		id = cas
+		value = -10000
+	
+	}
+}

--- a/common/ai_strategy_plans/SOV_MP_plan.txt
+++ b/common/ai_strategy_plans/SOV_MP_plan.txt
@@ -1,0 +1,99 @@
+SOV_MP_1 = {
+	name = "SOV Multiplayer Plan 1"
+	desc = "Collectivism"
+
+	enable = {
+		original_tag = SOV
+			has_game_rule = {
+				rule = SOV_ai_behavior
+				option = SOV_MP_1
+				}
+			}
+
+	abort = {
+	}
+
+	ai_national_focuses = {
+		SOV_stalin_constitution
+		SOV_collectivist_propaganda
+		SOV_finish_five_year_plan
+		SOV_production_effort
+		SOV_extra_tech_slot_early
+		SOV_move_industry_to_urals #just in case
+		SOV_defense_of_moscow #just in case
+		#1937
+		SOV_militarized_schools
+		SOV_workers_culture
+		SOV_infrastructure_effort
+		SOV_improve_railway
+		SOV_great_purge
+		#1938
+		SOV_rehabilitated_military
+		SOV_military_reorganization
+		#1939
+		SOV_lessons_of_war
+		SOV_research_city_experiment
+		SOV_diversify_the_programme
+		SOV_closed_city_network
+		SOV_tranformation_of_nature
+		#1940
+		SOV_socialist_realism
+		SOV_transpolar_flights
+		SOV_women_pilots
+		SOV_smersh
+	}
+	
+	focus_factors = {
+		SOV_peoples_commissariat = 0
+	}
+
+	research = {
+
+	}
+
+	ideas = {
+		war_economy = 1000
+	}
+
+	traits = {
+		captain_of_industry = 10
+		popular_figurehead = 5
+	}
+
+	
+
+	# Keep small, as it is used as a factor for some things (such as research needs)
+	# Recommended around 1.0. Useful for relation between plans
+	weight = {
+		factor = 1.0
+		modifier = {
+			factor = 1.0
+		}
+	}
+
+}
+
+SOV_MP_1_CivBuildup = {
+	name = "Sovjet Civ Buildup"
+	desc = ""
+
+	enable = {
+		original_tag = SOV
+		has_game_rule = {
+			rule = SOV_ai_behavior
+			option = SOV_MP_1
+		}
+		date < 1938.9.15
+	}
+	abort_when_not_enabled = yes
+
+	ideas = {
+		service_by_requirement = 0
+	}
+	
+	ai_strategy = {
+		type = building_target
+		id = industrial_complex
+		value = 100
+	}
+}

--- a/common/ai_strategy_plans/USA_MP_plan.txt
+++ b/common/ai_strategy_plans/USA_MP_plan.txt
@@ -1,0 +1,90 @@
+USA_MP_1 = {
+	name = "USA_MP_1"
+	desc = "Mulitplayer script behavior for US"
+
+	enable = {
+		original_tag = USA
+		has_game_rule = {
+			rule = USA_ai_behavior
+			option = USA_MP_1
+		}
+	}
+
+	abort = {
+	}
+
+	ai_national_focuses = {
+		USA_continue_the_new_deal
+		USA_wpa
+		USA_office_of_scientific_research_and_development
+		USA_agricultural_adjustment_act
+		USA_fair_labour_standards_act
+		USA_federal_housing_act
+		USA_neutrality_act
+		#1937
+		USA_arsenal_of_democracy
+		USA_the_giant_wakes
+		USA_scientist_haven
+		USA_war_department
+		USA_selective_training_act
+		USA_air_war_plans_division
+		#1938
+		USA_second_vinson_act
+		USA_two_ocean_navy_act
+		USA_bureau_of_ships
+		USA_lend_lease_act
+		USA_escort_effort
+		USA_military_construction
+		#1939
+		USA_USACE_projects
+		USA_wartime_industry
+		USA_louisiana_maneuvers
+		USA_airborne_divisions
+		USA_army_of_the_united_states
+		#1940
+		USA_womens_armed_service_integration_act
+		USA_build_the_pentagon
+		USA_department_of_defense
+		#1941
+		#1942
+		#1943
+	}
+
+	focus_factors = {
+		USA_suspend_the_presecution = 0 # well done, not medium rare
+	}
+
+	research = {
+
+	}
+
+	ideas = {
+		USA_robert_taft = 1000
+		partial_economic_mobilisation = 400
+		war_economy = 500
+		USA_henry_morgenthau = 10
+		omar_bradley = 5
+
+	}
+	traits = {
+		war_industrialist = 5
+		financial_expert = 10
+		silent_workhorse = 25
+	}
+
+	ai_strategy = {
+		type = support
+		id = "ENG"			
+		value = 200
+	}
+
+	# Keep small, as it is used as a factor for some things (such as research needs)
+	# Recommended around 1.0. Useful for relation between plans
+	weight = {
+		factor = 1.0
+		modifier = {
+			factor = 1.0
+		}
+	}
+
+}

--- a/common/ai_strategy_plans/YUG_MP_plan.txt
+++ b/common/ai_strategy_plans/YUG_MP_plan.txt
@@ -1,5 +1,5 @@
-YUG_historical = {
-	name = "Yugoslavian historical plan"
+YUG_MP_plan = {
+	name = "Yugoslavian MP plan"
 	desc = "Small Buff for Italy, Yugo industrilizes earlier and gets Pannonian Oil"
 
 	enable = {

--- a/common/ai_strategy_plans/YUG_MP_plan.txt
+++ b/common/ai_strategy_plans/YUG_MP_plan.txt
@@ -1,0 +1,72 @@
+YUG_historical = {
+	name = "Yugoslavian historical plan"
+	desc = "Small Buff for Italy, Yugo industrilizes earlier and gets Pannonian Oil"
+
+	enable = {
+		original_tag = YUG
+		has_dlc = "Death or Dishonor"
+		has_game_rule = {
+			rule = YUG_ai_behavior
+			option = YUG_MP_1
+		}
+	}
+
+	abort = {
+	}
+
+	ai_national_focuses = {
+		YUG_western_focus
+		YUG_industrialization_program
+		YUG_expand_the_mining_industry
+		YUG_develop_civilian_industry
+		YUG_modernize_the_air_force
+		YUG_purchase_foreign
+		YUG_rare_minerals_exploitation
+		YUG_exploit_the_pannonian_deposits
+		YUG_expand_the_serbian_shipyards
+		YUG_friendship_treaty_with_italy
+		YUG_attract_foreign_capital
+		YUG_ban_slovene_nationalist_parties
+		YUG_traditional_values
+		YUG_concessions_for_macedonians
+		YUG_crush_the_ustasa
+		YUG_expand_the_university_of_zagreb
+		YUG_improve_serbian_rail_network
+		YUG_improve_light_industry
+		YUG_serbian_steel
+		YUG_expand_the_university_of_belgrad
+		YUG_central_management
+		YUG_expand_the_sarajevo_arsenals
+		YUG_motorized_logistics
+		YUG_armored_cavalry
+		YUG_tank_conversions
+		YUG_army_maneuvers
+		YUG_supremacy_of_defense
+		YUG_artillery_regiments
+	}
+
+	research = {
+	}
+
+	ideas = {
+		
+	}
+
+	traits = {
+	}
+
+	# Keep small, as it is used as a factor for some things (such as research needs)
+	# Recommended around 1.0. Useful for relation between plans
+	weight = {
+		factor = 1.0
+		modifier = {
+			factor = 1.0
+		}
+	}
+
+	focus_factors = {
+		
+	}
+
+}
+

--- a/common/decisions/foreign_influence.txt
+++ b/common/decisions/foreign_influence.txt
@@ -1,0 +1,516 @@
+foreign_influence = {
+
+	# Decisions for masters to push their ideology onto puppets
+	# Note that subject status is not checked due to those only appearing in DLC
+	# (Subjects are puppets with high autonomy)
+
+	nation_building = {
+
+		icon = eng_propaganda_campaigns
+
+		days_remove = 120
+		
+		available = {
+			FROM = {
+				is_puppet_of = ROOT
+			}
+			FROM = {
+				democratic < 0.9
+			}
+			OR = {
+				political_power_daily > 0.5
+				has_political_power > 60
+			}
+		}
+
+		visible = {
+			has_government = democratic
+			FROM = {
+				is_puppet_of = ROOT
+				democratic < 0.99
+			}
+		}
+
+		target_array = subjects
+
+		target_trigger = {
+			FROM = {
+				is_puppet_of = ROOT
+			}
+		}
+
+		complete_effect = {
+			FROM = { add_timed_idea = { idea = nation_building days = 120 } }
+		}
+
+		modifier = {
+			political_power_cost = 0.5
+		}
+
+		ai_will_do = {
+			factor = 0
+		}
+	}
+	
+	socialist_education = {
+
+		icon = eng_propaganda_campaigns
+
+		days_remove = 120
+		
+		available = {
+			FROM = {
+				is_puppet_of = ROOT
+			}
+			FROM = {
+				communism < 0.9
+			}
+			OR = {
+				political_power_daily > 0.5
+				has_political_power > 60
+			}
+		}
+
+		visible = {
+			has_government = communism
+			NOT = {
+				AND = {
+					tag = ENG
+					has_completed_focus = ENG_concessions_to_the_trade_unions
+					FROM = {
+						OR = {
+							tag = CAN
+							tag = SAF
+							tag = RAJ
+							tag = AST
+							tag = NZL
+						}
+						has_government = communism
+					}
+				}
+			}
+			FROM = {
+				is_puppet_of = ROOT
+				communism < 0.99
+			}
+		}
+
+		target_array = subjects
+
+		target_trigger = {
+			FROM = {
+				is_puppet_of = ROOT
+			}
+		}
+
+		complete_effect = {
+			FROM = {
+				add_timed_idea = { idea = socialist_education days = 120 }
+			}
+		}
+		modifier = {
+			political_power_cost = 0.5
+		}
+
+		ai_will_do = {
+			factor = 0
+		}
+	}
+	
+	paramilitary_training = {
+
+		icon = eng_propaganda_campaigns
+
+		days_remove = 120
+		
+		available = {
+			FROM = {
+				is_puppet_of = ROOT
+			}
+			FROM = {
+				fascism < 0.9
+			}
+			OR = {
+				political_power_daily > 0.5
+				has_political_power > 60
+			}
+		}
+
+		visible = {
+			has_government = fascism
+			NOT = {
+				AND = {
+					tag = ENG
+					has_completed_focus = ENG_organize_the_blackshirts
+					FROM = {
+						OR = {
+							tag = CAN
+							tag = SAF
+							tag = RAJ
+							tag = AST
+							tag = NZL
+						}
+						has_government = fascism
+					}
+				}
+			}
+			FROM = {
+				is_puppet_of = ROOT
+				fascism < 0.99
+			}
+		}
+
+		target_array = subjects
+
+		target_trigger = {
+			FROM = {
+				is_puppet_of = ROOT
+			}
+		}
+
+		complete_effect = {
+			FROM = {
+				add_timed_idea = { idea = paramilitary_training days = 120 }
+			}
+		}
+
+		modifier = {
+			political_power_cost = 0.5
+		}
+
+		ai_will_do = {
+			factor = 0
+		}
+	}
+	
+	military_parade = {
+
+		icon = eng_propaganda_campaigns
+
+		days_remove = 120
+		
+		available = {
+			FROM = {
+				is_puppet_of = ROOT
+				neutrality < 0.9
+			}
+			OR = {
+				political_power_daily > 0.5
+				has_political_power > 60
+			}
+		}
+
+		visible = {
+			has_government = neutrality
+			FROM = {
+				is_puppet_of = ROOT
+				neutrality < 0.99
+			}
+		}
+
+		target_array = subjects
+
+		target_trigger = {
+			FROM = {
+				is_puppet_of = ROOT
+			}
+		}
+
+		complete_effect = {
+			FROM = {
+				add_timed_idea = { idea = military_parade days = 120 }
+			}
+		}
+
+		modifier = {
+			political_power_cost = 0.5
+		}
+
+		ai_will_do = {
+			factor = 0
+		}
+	}
+	
+	police_action = {
+
+		icon = generic_prepare_civil_war
+		
+		cost = 50
+		
+		available = {
+			FROM = {
+				is_puppet_of = ROOT
+			}
+			FROM = {
+				democratic > 0.6
+			}
+			FROM = {
+				NOT = { has_government = democratic }
+			}
+		}
+
+		visible = {
+			has_government = democratic
+			FROM = {
+				is_puppet_of = ROOT
+				NOT = { has_government = democratic }
+			}
+		}
+
+		target_array = subjects
+
+		target_trigger = {
+			FROM = {
+				is_puppet_of = ROOT
+			}
+		}
+
+		complete_effect = {
+			FROM = { country_event = { id = mtg_generic.1 } }
+			FROM = {
+				add_timed_idea = {
+					idea = political_turmoil
+					days = 365
+				}
+			}
+			FROM = {
+				set_politics = {
+					ruling_party = democratic
+					elections_allowed = yes
+				}
+			}
+		}
+		
+		ai_will_do = {
+			factor = 0
+		}
+	}
+	
+	fraternal_republic = {
+
+		icon = generic_prepare_civil_war
+		
+		cost = 50
+		
+		available = {
+			FROM = {
+				is_puppet_of = ROOT
+			}
+			FROM = {
+				communism > 0.6
+			}
+			FROM = {
+				NOT = { has_government = communism }
+			}
+		}
+
+		visible = {
+			has_government = communism
+			FROM = {
+				is_puppet_of = ROOT
+				NOT = { has_government = communism }
+			}
+			NOT = {
+				AND = {
+					tag = ENG
+					has_completed_focus = ENG_concessions_to_the_trade_unions
+					FROM = {
+						OR = {
+							tag = CAN
+							tag = SAF
+							tag = RAJ
+							tag = AST
+							tag = NZL
+						}
+					}
+				}
+			}
+		}
+
+		target_array = subjects
+
+		target_trigger = {
+			FROM = {
+				is_puppet_of = ROOT
+			}
+		}
+
+		complete_effect = {
+			FROM = { country_event = { id = mtg_generic.1 } }
+			FROM = {
+				add_timed_idea = {
+					idea = political_turmoil
+					days = 365
+				}
+			}
+			FROM = {
+				set_politics = {
+					ruling_party = communism
+					elections_allowed = no
+				}
+			}
+		}
+		
+		ai_will_do = {
+			factor = 0
+		}
+	}
+	
+	ultranationalist_coup = {
+
+		icon = generic_prepare_civil_war
+		
+		cost = 50
+		
+		available = {
+			FROM = {
+				is_puppet_of = ROOT
+			}
+			FROM = {
+				fascism > 0.6
+			}
+			FROM = {
+				NOT = { has_government = fascism }
+			}
+		}
+
+		visible = {
+			has_government = fascism
+			FROM = {
+				is_puppet_of = ROOT
+				NOT = { has_government = fascism }
+			}
+			NOT = {
+				AND = {
+					tag = ENG
+					has_completed_focus = ENG_organize_the_blackshirts
+					FROM = {
+						OR = {
+							tag = CAN
+							tag = SAF
+							tag = RAJ
+							tag = AST
+							tag = NZL
+						}
+					}
+				}
+			}
+		}
+
+		target_array = subjects
+
+		target_trigger = {
+			FROM = {
+				is_puppet_of = ROOT
+			}
+		}
+
+		complete_effect = {
+			FROM = { country_event = { id = mtg_generic.1 } }
+			FROM = {
+				add_timed_idea = {
+					idea = political_turmoil
+					days = 365
+				}
+			}
+			FROM = {
+				set_politics = {
+					ruling_party = fascism
+					elections_allowed = no
+				}
+			}
+		}
+		
+		ai_will_do = {
+			factor = 0
+		}
+	}
+	
+	military_dictatorship = {
+
+		icon = generic_prepare_civil_war
+		
+		cost = 50
+		
+		available = {
+			FROM = {
+				is_puppet_of = ROOT
+			}
+			FROM = {
+				neutrality > 0.6
+			}
+			FROM = {
+				NOT = { has_government = neutrality }
+			}
+		}
+
+		visible = {
+			has_government = neutrality
+			FROM = {
+				is_puppet_of = ROOT
+				NOT = { has_government = neutrality }
+			}
+		}
+
+		target_array = subjects
+
+		target_trigger = {
+			FROM = {
+				is_puppet_of = ROOT
+			}
+		}
+
+		complete_effect = {
+			FROM = { country_event = { id = mtg_generic.1 } }
+			FROM = {
+				add_timed_idea = {
+					idea = political_turmoil
+					days = 365
+				}
+			}
+			FROM = {
+				set_politics = {
+					ruling_party = neutrality
+					elections_allowed = no
+				}
+			}
+		}
+		
+		ai_will_do = {
+			factor = 0
+		}
+	}
+	
+	instantiate_collaboration = {
+		icon = generic_prepare_civil_war
+		
+		cost = 0
+
+		available = {
+			has_core_occupation_modifier = {
+				occupied_country_tag = FROM
+				modifier = compliance_80
+			}
+		}
+        visible = {
+			has_rule = can_create_collaboration_government
+			is_available_to_collaboration_government = yes
+			has_core_occupation_modifier = {
+				occupied_country_tag = FROM
+				modifier = compliance_60
+			}
+        }
+
+		complete_effect = {
+			set_temp_variable = { country_to_initiate = FROM }
+			instantiate_collaboration_government = yes
+		}
+
+		ai_will_do = {
+			factor = 0
+		}
+		
+		target_non_existing = yes
+		target_array = occupied_countries
+	}
+}

--- a/common/games_rules/02_game_rules_AI_Scripts.txt
+++ b/common/games_rules/02_game_rules_AI_Scripts.txt
@@ -1,0 +1,1175 @@
+	#
+# List of options showing in the Game Rules screen
+#
+# format is:
+# rule_token = {
+#	name = "TEXT_KEY_FOR_NAME"
+#	required_dlc = "Name of the Required DLC"
+#	desc = "TEXT_KEY_FOR_LONG_DESC"
+#	group = "TEXT_KEY_FOR_GROUP"					# Used for filtering. A single rule can be in multiple groups 
+#	icon = gfx_option_token							# Optional icon
+#	option = {										# Unless other specified, the first option is the default option
+#		name = option_token
+#		text = "TEXT_KEY_FOR_OPTION_NAME"
+#		allow_achievements = no						# Achievements cannot be earned if one or more game rules are set to an option that has this property set to no.
+#													# If not specified, this is set to yes for default options and no for all other options.
+#	}
+#	default = {										# Specify an option with the "default" token to override the behavior of treating the first option as the default.
+#		name = option_token
+#		text = "TEXT_KEY_FOR_OPTION_NAME"
+#		...
+#	}
+# }
+
+
+ ##  ###     ###  ### #  #  ##  #   # ###  ##  ###  
+#  #  #      #  # #   #  # #  # #   #  #  #  # #  # 
+####  #      ###  ##  #### ####  # #   #  #  # ###  
+#  #  #      #  # #   #  # #  #  # #   #  #  # #  # 
+#  # ###     ###  ### #  # #  #   #   ###  ##  #  # 
+
+GER_ai_behavior = {
+	name = "GER_AI_BEHAVIOR"
+	required_dlc = "Waking the Tiger"
+	group = "RULE_GROUP_AI_BEHAVIOR"
+	option = {
+		name = DEFAULT
+		text = "RULE_OPTION_DEFAULT"
+		desc = "RULE_OPTION_DEFAULT_AI_DESC"
+	}
+	option = {
+		name = FASCIST
+		text = "RULE_OPTION_FASCIST"
+		desc = "RULE_OPTION_FASCIST_GER_AI_DESC"
+		allow_achievements = yes
+	}
+	option = {
+		name = DEMOCRATIC
+		text = "RULE_OPTION_DEMOCRATIC"
+		desc = "RULE_DEMOCRATIC_GER_AI_DESC"
+	}
+	option = {
+		name = KAISER
+		text = "RULE_OPTION_KAISER"
+		desc = "RULE_KAISER_GER_AI_DESC"
+	}
+	option = {
+		name = RANDOM
+		text = "RULE_OPTION_RANDOM"
+		desc = "RULE_OPTION_RANDOM_AI_DESC"
+	}
+	default = {
+		name = GER_MP_1
+		text = "RULE_OPTION_GER_MP_1"
+		desc = "RULE_OPTION_GER_MP_1_DESC"
+	}
+}
+SOV_ai_behavior = {
+	name = "SOV_AI_BEHAVIOR"
+	group = "RULE_GROUP_AI_BEHAVIOR"
+	option = {
+		name = DEFAULT
+		text = "RULE_OPTION_DEFAULT"
+		desc = "RULE_OPTION_DEFAULT_AI_DESC"
+	}
+	option = {
+		name = HISTORICAL
+		text = "RULE_OPTION_HISTORICAL"
+		desc = "RULE_OPTION_HISTORICAL_SOV_AI_DESC"
+		allow_achievements = yes
+	}
+	option = {
+		name = ALTERNATE
+		text = "RULE_OPTION_ALTERNATE"
+		desc = "RULE_OPTION_ALTERNATE_SOV_AI_DESC"
+	}
+	option = {
+		name = RANDOM
+		text = "RULE_OPTION_RANDOM"
+		desc = "RULE_OPTION_RANDOM_AI_DESC"
+	}
+	default = {
+		name = SOV_MP_1
+		text = "RULE_OPTION_SOV_MP_1"
+		desc = "RULE_OPTION_SOV_MP_1_DESC"
+	}
+}
+JAP_ai_behavior = {
+	name = "JAP_AI_BEHAVIOR"
+	required_dlc = "Waking the Tiger"
+	group = "RULE_GROUP_AI_BEHAVIOR"
+	option = {
+		name = DEFAULT
+		text = "RULE_OPTION_DEFAULT"
+		desc = "RULE_OPTION_DEFAULT_AI_DESC"
+	}
+	option = {
+		name = COMMUNIST
+		text = "RULE_OPTION_COMMUNIST"
+		desc = "RULE_OPTION_COMMUNIST_JAP_AI_DESC"
+	}
+	option = {
+		name = NEUTRALITY
+		text = "RULE_OPTION_NEUTRALITY"
+		desc = "RULE_OPTION_NEUTRALITY_JAP_AI_DESC"
+	}
+	option = {
+		name = DEMOCRATIC
+		text = "RULE_OPTION_DEMOCRATIC"
+		desc = "RULE_DEMOCRATIC_JAP_AI_DESC"
+	}
+	option = {
+		name = FASCIST
+		text = "RULE_OPTION_FASCIST"
+		desc = "RULE_FASCIST_JAP_AI_DESC"
+		allow_achievements = yes
+	}
+	option = {
+		name = RANDOM
+		text = "RULE_OPTION_RANDOM"
+		desc = "RULE_OPTION_RANDOM_AI_DESC"
+	}
+	default = {
+		name = JAP_MP_1
+		text = "RULE_OPTION_JAP_MP_1"
+		desc = "RULE_OPTION_JAP_MP_1_DESC"
+	}
+}
+
+ITA_ai_behavior = {
+	name = "ITA_AI_BEHAVIOR"
+	group = "RULE_GROUP_AI_BEHAVIOR"
+	option = {
+		name = DEFAULT
+		text = "RULE_OPTION_DEFAULT"
+		desc = "RULE_OPTION_DEFAULT_AI_DESC"
+	}
+	option = {
+		name = FASCIST_HISTORICAL
+		text = "RULE_OPTION_FASCIST_HISTORICAL"
+		desc = "RULE_FASCIST_HISTORICAL_ITA_AI_DESC" 
+		allow_achievements = yes
+	}
+	option = {
+		name = FASCIST_ALTERNATE
+		text = "RULE_OPTION_FASCIST_ALTERNATE"
+		desc = "RULE_FASCIST_ALTERNATE_ITA_AI_DESC"
+	}
+	option = {
+		name = RANDOM
+		text = "RULE_OPTION_RANDOM"
+		desc = "RULE_OPTION_RANDOM_AI_DESC"
+	}
+	default = {
+		name = ITA_MP_1
+		text = "RULE_OPTION_ITA_MP_1"
+		desc = "RULE_OPTION_ITA_MP_1_DESC"
+	}
+}
+
+FRA_ai_behavior = {
+	name = "FRA_AI_BEHAVIOR"
+	required_dlc = "La Resistance"
+	group = "RULE_GROUP_AI_BEHAVIOR"
+	option = {
+		name = DEFAULT
+		text = "RULE_OPTION_DEFAULT"
+		desc = "RULE_OPTION_DEFAULT_AI_DESC"
+	}
+	option = {
+		name = COMMUNIST
+		text = "RULE_OPTION_COMMUNIST"
+		desc = "RULE_OPTION_COMMUNIST_FRA_AI_DESC"
+	}
+	option = {
+		name = DEMOCRATIC_HISTORICAL
+		text = "RULE_OPTION_DEMOCRATIC_HISTORICAL"
+		desc = "RULE_OPTION_DEMOCRATIC_HISTORICAL_FRA_AI_DESC"
+		allow_achievements = yes
+	}
+	option = {
+		name = DEMOCRATIC_ALTERNATE
+		text = "RULE_OPTION_DEMOCRATIC_ALTERNATE"
+		desc = "RULE_DEMOCRATIC_ALTERNATE_FRA_AI_DESC"
+	}
+	option = {
+		name = FASCIST
+		text = "RULE_OPTION_FASCIST"
+		desc = "RULE_FASCIST_FRA_AI_DESC"
+	}
+	option = {
+		name = ORLEANIST
+		text = "RULE_OPTION_MONARCHIST_ORLEANIST"
+		desc = "RULE_MONARCHIST_ORLEANIST_FRA_AI_DESC"
+	}
+	option = {
+		name = LEGITIMIST
+		text = "RULE_OPTION_MONARCHIST_LEGITIMIST"
+		desc = "RULE_MONARCHIST_LEGITIMIST_FRA_AI_DESC"
+	}
+	option = {
+		name = BONAPARTIST
+		text = "RULE_OPTION_MONARCHIST_BONAPARTIST"
+		desc = "RULE_MONARCHIST_BONAPARTIST_FRA_AI_DESC"
+	}
+	option = {
+		name = RANDOM
+		text = "RULE_OPTION_RANDOM"
+		desc = "RULE_OPTION_RANDOM_AI_DESC"
+	}
+	default = {
+		name = FRA_MP_1
+		text = "RULE_OPTION_FRA_MP_1"
+		desc = "RULE_OPTION_FRA_MP_1_DESC"
+	}
+	option = {
+		name = FRA_MP_2
+		text = "RULE_OPTION_FRA_MP_2"
+		desc = "RULE_OPTION_FRA_MP_2_DESC"
+	}
+}
+
+POL_ai_behavior = {
+	name = "POL_AI_BEHAVIOR"
+	group = "RULE_GROUP_AI_BEHAVIOR"
+	required_dlc = "Poland: United and Ready"
+	option = {
+		name = DEFAULT
+		text = "RULE_OPTION_DEFAULT"
+		desc = "RULE_OPTION_DEFAULT_AI_DESC"
+	}
+	option = {
+		name = COMMUNIST
+		text = "RULE_OPTION_COMMUNIST"
+		desc = "RULE_OPTION_COMMUNIST_POL_AI_DESC"
+	}
+	option = {
+		name = HISTORICAL
+		text = "RULE_OPTION_HISTORICAL"
+		desc = "RULE_OPTION_HISTORICAL_POL_AI_DESC"
+		allow_achievements = yes
+	}
+	option = {
+		name = FASCIST
+		text = "RULE_OPTION_FASCIST"
+		desc = "RULE_FASCIST_POL_AI_DESC"
+	}
+	option = {
+		name = RANDOM
+		text = "RULE_OPTION_RANDOM"
+		desc = "RULE_OPTION_RANDOM_AI_DESC"
+	}
+	default = {
+		name = POL_MP_1
+		text = "RULE_OPTION_POL_MP_1"
+		desc = "RULE_OPTION_POL_MP_1_DESC"
+	}
+}
+
+AST_ai_behavior = {
+	name = "AST_AI_BEHAVIOR"
+	group = "RULE_GROUP_AI_BEHAVIOR"
+	required_dlc = "Together for Victory"
+	option = {
+		name = DEFAULT
+		text = "RULE_OPTION_DEFAULT"
+		desc = "RULE_OPTION_DEFAULT_AI_DESC"
+	}
+	option = {
+		name = COMMUNIST
+		text = "RULE_OPTION_COMMUNIST"
+		desc = "RULE_OPTION_COMMUNIST_AST_AI_DESC"
+	}
+	option = {
+		name = DEMOCRATIC_HISTORICAL
+		text = "RULE_OPTION_DEMOCRATIC_HISTORICAL"
+		desc = "RULE_OPTION_DEMOCRATIC_HISTORICAL_AST_AI_DESC"
+		allow_achievements = yes
+	}
+	option = {
+		name = DEMOCRATIC_ALTERNATE
+		text = "RULE_OPTION_DEMOCRATIC_ALTERNATE"
+		desc = "RULE_DEMOCRATIC_ALTERNATE_AST_AI_DESC"
+	}
+	option = {
+		name = FASCIST
+		text = "RULE_OPTION_FASCIST"
+		desc = "RULE_FASCIST_AST_AI_DESC"
+	}
+	option = {
+		name = RANDOM
+		text = "RULE_OPTION_RANDOM"
+		desc = "RULE_OPTION_RANDOM_AI_DESC"
+	}
+	default = {
+		name = AST_MP_1
+		text = "RULE_OPTION_AST_MP_1"
+		desc = "RULE_OPTION_AST_MP_1_DESC"
+	}
+}
+
+CAN_ai_behavior = {
+	name = "CAN_AI_BEHAVIOR"
+	group = "RULE_GROUP_AI_BEHAVIOR"
+	required_dlc = "Together for Victory"
+	option = {
+		name = DEFAULT
+		text = "RULE_OPTION_DEFAULT"
+		desc = "RULE_OPTION_DEFAULT_AI_DESC"
+	}
+	option = {
+		name = COMMUNIST
+		text = "RULE_OPTION_COMMUNIST"
+		desc = "RULE_OPTION_COMMUNIST_CAN_AI_DESC"
+	}
+	option = {
+		name = DEMOCRATIC_HISTORICAL
+		text = "RULE_OPTION_DEMOCRATIC_HISTORICAL"
+		desc = "RULE_OPTION_DEMOCRATIC_HISTORICAL_CAN_AI_DESC"
+		allow_achievements = yes
+	}
+	option = {
+		name = DEMOCRATIC_ALTERNATE
+		text = "RULE_OPTION_DEMOCRATIC_ALTERNATE"
+		desc = "RULE_DEMOCRATIC_ALTERNATE_CAN_AI_DESC"
+	}
+	option = {
+		name = FASCIST
+		text = "RULE_OPTION_FASCIST"
+		desc = "RULE_FASCIST_CAN_AI_DESC"
+	}
+	option = {
+		name = RANDOM
+		text = "RULE_OPTION_RANDOM"
+		desc = "RULE_OPTION_RANDOM_AI_DESC"
+	}
+	default = {
+		name = CAN_MP_1
+		text = "RULE_OPTION_CAN_MP_1"
+		desc = "RULE_OPTION_CAN_MP_1_DESC"
+	}
+}
+
+SAF_ai_behavior = {
+	name = "SAF_AI_BEHAVIOR"
+	group = "RULE_GROUP_AI_BEHAVIOR"
+	required_dlc = "Together for Victory"
+	option = {
+		name = DEFAULT
+		text = "RULE_OPTION_DEFAULT"
+		desc = "RULE_OPTION_DEFAULT_AI_DESC"
+	}
+	option = {
+		name = COMMUNIST
+		text = "RULE_OPTION_COMMUNIST"
+		desc = "RULE_OPTION_COMMUNIST_SAF_AI_DESC"
+	}
+	option = {
+		name = DEMOCRATIC_HISTORICAL
+		text = "RULE_OPTION_DEMOCRATIC_HISTORICAL"
+		desc = "RULE_OPTION_DEMOCRATIC_HISTORICAL_SAF_AI_DESC"
+		allow_achievements = yes
+	}
+	option = {
+		name = DEMOCRATIC_ALTERNATE
+		text = "RULE_OPTION_DEMOCRATIC_ALTERNATE"
+		desc = "RULE_DEMOCRATIC_ALTERNATE_SAF_AI_DESC"
+	}
+	option = {
+		name = FASCIST
+		text = "RULE_OPTION_FASCIST"
+		desc = "RULE_FASCIST_SAF_AI_DESC"
+	}
+	option = {
+		name = RANDOM
+		text = "RULE_OPTION_RANDOM"
+		desc = "RULE_OPTION_RANDOM_AI_DESC"
+	}
+	default = {
+		name = SAF_MP_1
+		text = "RULE_OPTION_SAF_MP_1"
+		desc = "RULE_OPTION_SAF_MP_1_DESC"
+	}
+}
+NZL_ai_behavior = {
+	name = "NZL_AI_BEHAVIOR"
+	group = "RULE_GROUP_AI_BEHAVIOR"
+	required_dlc = "Together for Victory"
+	option = {
+		name = DEFAULT
+		text = "RULE_OPTION_DEFAULT"
+		desc = "RULE_OPTION_DEFAULT_AI_DESC"
+	}
+	option = {
+		name = COMMUNIST
+		text = "RULE_OPTION_COMMUNIST"
+		desc = "RULE_OPTION_COMMUNIST_NZL_AI_DESC"
+	}
+	option = {
+		name = DEMOCRATIC_HISTORICAL
+		text = "RULE_OPTION_DEMOCRATIC_HISTORICAL"
+		desc = "RULE_OPTION_DEMOCRATIC_HISTORICAL_NZL_AI_DESC"
+		allow_achievements = yes
+	}
+	option = {
+		name = DEMOCRATIC_ALTERNATE
+		text = "RULE_OPTION_DEMOCRATIC_ALTERNATE"
+		desc = "RULE_DEMOCRATIC_ALTERNATE_NZL_AI_DESC"
+	}
+	option = {
+		name = FASCIST
+		text = "RULE_OPTION_FASCIST"
+		desc = "RULE_FASCIST_NZL_AI_DESC"
+	}
+	option = {
+		name = RANDOM
+		text = "RULE_OPTION_RANDOM"
+		desc = "RULE_OPTION_RANDOM_AI_DESC"
+	}
+	default = {
+		name = NZL_MP_1
+		text = "RULE_OPTION_NZL_MP_1"
+		desc = "RULE_OPTION_NZL_MP_1_DESC"
+	}
+}
+RAJ_ai_behavior = {
+	name = "RAJ_AI_BEHAVIOR"
+	group = "RULE_GROUP_AI_BEHAVIOR"
+	required_dlc = "Together for Victory"
+	option = {
+		name = DEFAULT
+		text = "RULE_OPTION_DEFAULT"
+		desc = "RULE_OPTION_DEFAULT_AI_DESC"
+	}
+	option = {
+		name = COMMUNIST
+		text = "RULE_OPTION_COMMUNIST"
+		desc = "RULE_OPTION_COMMUNIST_RAJ_AI_DESC"
+	}
+	option = {
+		name = DEMOCRATIC_HISTORICAL
+		text = "RULE_OPTION_HISTORICAL"
+		desc = "RULE_OPTION_DEMOCRATIC_HISTORICAL_RAJ_AI_DESC"
+		allow_achievements = yes
+	}
+	option = {
+		name = FASCIST
+		text = "RULE_OPTION_FASCIST"
+		desc = "RULE_FASCIST_RAJ_AI_DESC"
+	}
+	option = {
+		name = RANDOM
+		text = "RULE_OPTION_RANDOM"
+		desc = "RULE_OPTION_RANDOM_AI_DESC"
+	}
+	default = {
+		name = RAJ_MP_1
+		text = "RULE_OPTION_RAJ_MP_1"
+		desc = "RULE_OPTION_RAJ_MP_1_DESC"
+	}
+}
+
+HUN_ai_behavior = {
+	name = "HUN_AI_BEHAVIOR"
+	group = "RULE_GROUP_AI_BEHAVIOR"
+	required_dlc = "Death or Dishonor"
+	option = {
+		name = DEFAULT
+		text = "RULE_OPTION_DEFAULT"
+		desc = "RULE_OPTION_DEFAULT_AI_DESC"
+	}
+	option = {
+		name = COMMUNIST
+		text = "RULE_OPTION_COMMUNIST"
+		desc = "RULE_OPTION_COMMUNIST_HUN_AI_DESC"
+	}
+	option = {
+		name = AUSTRIA_HUNGARY
+		text = "RULE_OPTION_AUSTRIA_HUNGARY"
+		desc = "RULE_OPTION_AUSTRIA_HUNGARY_HUN_AI_DESC"
+	}
+	option = {
+		name = DEMOCRATIC
+		text = "RULE_OPTION_DEMOCRATIC"
+		desc = "RULE_OPTION_DEMOCRATIC_HUN_AI_DESC"
+	}
+	option = {
+		name = FASCIST_ALTERNATE
+		text = "RULE_OPTION_FASCIST_ALTERNATE"
+		desc = "RULE_FASCIST_ALTERNATE_HUN_AI_DESC"
+	}
+	option = {
+		name = FASCIST_HISTORICAL
+		text = "RULE_OPTION_FASCIST_HISTORICAL"
+		desc = "RULE_FASCIST_HUN_AI_DESC"
+		allow_achievements = yes
+	}
+	option = {
+		name = RANDOM
+		text = "RULE_OPTION_RANDOM"
+		desc = "RULE_OPTION_RANDOM_AI_DESC"
+	}
+	default = {
+		name = HUN_MP_1
+		text = "RULE_OPTION_HUN_MP_1"
+		desc = "RULE_OPTION_HUN_MP_1_DESC"
+	}
+	option = {
+		name = HUN_MP_2
+		text = "RULE_OPTION_HUN_MP_2"
+		desc = "RULE_OPTION_HUN_MP_2_DESC"
+	}
+}
+
+ROM_ai_behavior = {
+	name = "ROM_AI_BEHAVIOR"
+	group = "RULE_GROUP_AI_BEHAVIOR"
+	required_dlc = "Death or Dishonor"
+	option = {
+		name = DEFAULT
+		text = "RULE_OPTION_DEFAULT"
+		desc = "RULE_OPTION_DEFAULT_AI_DESC"
+	}
+	option = {
+		name = BALKAN_DOMINANCE
+		text = "RULE_OPTION_BALKAN_DOMINANCE"
+		desc = "RULE_OPTION_BALKAN_DOMINANCE_ROM_AI_DESC"
+	}
+	option = {
+		name = DEMOCRATIC
+		text = "RULE_OPTION_DEMOCRATIC"
+		desc = "RULE_OPTION_DEMOCRATIC_ROM_AI_DESC"
+	}
+	option = {
+		name = COMMUNIST
+		text = "RULE_OPTION_COMMUNIST"
+		desc = "RULE_COMMUNIST_ROM_AI_DESC"
+	}
+	option = {
+		name = FASCIST_HISTORICAL
+		text = "RULE_OPTION_FASCIST_HISTORICAL"
+		desc = "RULE_FASCIST_ROM_AI_DESC"
+		allow_achievements = yes
+	}
+	option = {
+		name = RANDOM
+		text = "RULE_OPTION_RANDOM"
+		desc = "RULE_OPTION_RANDOM_AI_DESC"
+	}
+	default = {
+		name = ROM_MP_1
+		text = "RULE_OPTION_ROM_MP_1"
+		desc = "RULE_OPTION_ROM_MP_1_DESC"
+	}
+}
+
+BUL_ai_behavior = {
+	name = "BUL_AI_BEHAVIOR"
+	group = "RULE_GROUP_AI_BEHAVIOR"
+	option = {
+		name = DEFAULT
+		text = "RULE_OPTION_DEFAULT"
+		desc = "RULE_OPTION_DEFAULT_AI_DESC"
+	}
+	default = {
+		name = BUL_MP_1
+		text = "RULE_OPTION_BUL_MP_1"
+		desc = "RULE_OPTION_BUL_MP_1_DESC"
+	}
+}
+YUG_ai_behavior = {
+	name = "YUG_AI_BEHAVIOR"
+	group = "RULE_GROUP_AI_BEHAVIOR"
+	required_dlc = "Death or Dishonor"
+	option = {
+		name = DEFAULT
+		text = "RULE_OPTION_DEFAULT"
+		desc = "RULE_OPTION_DEFAULT_AI_DESC"
+	}
+	option = {
+		name = COMMUNIST
+		text = "RULE_OPTION_COMMUNIST"
+		desc = "RULE_OPTION_COMMUNIST_YUG_AI_DESC"
+	}
+	option = {
+		name = DEMOCRATIC
+		text = "RULE_OPTION_DEMOCRATIC"
+		desc = "RULE_OPTION_DEMOCRATIC_YUG_AI_DESC"
+	}
+	option = {
+		name = FASCIST
+		text = "RULE_OPTION_FASCIST"
+		desc = "RULE_FASCIST_YUG_AI_DESC"
+	}
+	option = {
+		name = HISTORICAL
+		text = "RULE_OPTION_HISTORICAL"
+		desc = "RULE_HISTORICAL_YUG_AI_DESC"
+		allow_achievements = yes
+	}
+	option = {
+		name = RANDOM
+		text = "RULE_OPTION_RANDOM"
+		desc = "RULE_OPTION_RANDOM_AI_DESC"
+	}
+	default = {
+		name = YUG_MP_1
+		text = "RULE_OPTION_YUG_MP_1"
+		desc = "RULE_OPTION_YUG_MP_1_DESC"
+	}
+}
+
+CZE_ai_behavior = {
+	name = "CZE_AI_BEHAVIOR"
+	group = "RULE_GROUP_AI_BEHAVIOR"
+	required_dlc = "Death or Dishonor"
+	default = {
+		name = DEFAULT
+		text = "RULE_OPTION_DEFAULT"
+		desc = "RULE_OPTION_DEFAULT_AI_DESC"
+	}
+	option = {
+		name = COMMUNIST
+		text = "RULE_OPTION_COMMUNIST"
+		desc = "RULE_OPTION_COMMUNIST_CZE_AI_DESC"
+	}
+	option = {
+		name = DEMOCRATIC
+		text = "RULE_OPTION_DEMOCRATIC"
+		desc = "RULE_OPTION_DEMOCRATIC_CZE_AI_DESC"
+	}
+	option = {
+		name = DEMOCRATIC_ALTERNATE
+		text = "RULE_OPTION_DEMOCRATIC_ALTERNATE"
+		desc = "RULE_OPTION_DEMOCRATIC_ALTERNATE_CZE_AI_DESC"
+	}
+	option = {
+		name = FASCIST
+		text = "RULE_OPTION_FASCIST"
+		desc = "RULE_FASCIST_CZE_AI_DESC"
+	}
+	option = {
+		name = HISTORICAL
+		text = "RULE_OPTION_HISTORICAL"
+		desc = "RULE_HISTORICAL_CZE_AI_DESC"
+		allow_achievements = yes
+	}
+	option = {
+		name = RANDOM
+		text = "RULE_OPTION_RANDOM"
+		desc = "RULE_OPTION_RANDOM_AI_DESC"
+	}
+}
+
+
+CHI_ai_behavior = {
+	name = "CHI_AI_BEHAVIOR"
+	required_dlc = "Waking the Tiger"
+	group = "RULE_GROUP_AI_BEHAVIOR"
+	option = {
+		name = DEFAULT
+		text = "RULE_OPTION_DEFAULT"
+		desc = "RULE_OPTION_DEFAULT_AI_DESC"
+	}
+	option = {
+		name = HISTORICAL
+		text = "RULE_OPTION_HISTORICAL"
+		desc = "RULE_OPTION_HISTORICAL_CHI_AI_DESC"
+		allow_achievements = yes
+	}
+	option = {
+		name = ALTERNATE
+		text = "RULE_OPTION_ALTERNATE"
+		desc = "RULE_OPTION_ALTERNATE_CHI_AI_DESC"
+	}
+	option = {
+		name = RANDOM
+		text = "RULE_OPTION_RANDOM"
+		desc = "RULE_OPTION_RANDOM_AI_DESC"
+	}
+	default = {
+		name = CHI_MP_1
+		text = "RULE_OPTION_CHI_MP_1"
+		desc = "RULE_OPTION_CHI_MP_1_DESC"
+	}
+}
+
+WL_ai_behavior = {
+	name = "WL_AI_BEHAVIOR"
+	required_dlc = "Waking the Tiger"
+	group = "RULE_GROUP_AI_BEHAVIOR"
+	option = {
+		name = DEFAULT
+		text = "RULE_OPTION_DEFAULT"
+		desc = "RULE_OPTION_DEFAULT_AI_DESC"
+	}
+	default = {
+		name = WL_MP_1
+		text = "RULE_OPTION_WL_MP_1"
+		desc = "RULE_OPTION_WL_MP_1_DESC"
+	}
+}
+PRC_ai_behavior = {
+	name = "PRC_AI_BEHAVIOR"
+	required_dlc = "Waking the Tiger"
+	group = "RULE_GROUP_AI_BEHAVIOR"
+	default = {
+		name = DEFAULT
+		text = "RULE_OPTION_DEFAULT"
+		desc = "RULE_OPTION_DEFAULT_AI_DESC"
+	}
+	option = {
+		name = HISTORICAL
+		text = "RULE_OPTION_HISTORICAL"
+		desc = "RULE_OPTION_HISTORICAL_PRC_AI_DESC"
+		allow_achievements = yes
+	}
+	option = {
+		name = ALTERNATE
+		text = "RULE_OPTION_ALTERNATE"
+		desc = "RULE_OPTION_ALTERNATE_PRC_AI_DESC"
+	}
+	option = {
+		name = RANDOM
+		text = "RULE_OPTION_RANDOM"
+		desc = "RULE_OPTION_RANDOM_AI_DESC"
+	}
+}
+MAN_ai_behavior = {
+	name = "MAN_AI_BEHAVIOR"
+	required_dlc = "Waking the Tiger"
+	group = "RULE_GROUP_AI_BEHAVIOR"
+	option = {
+		name = DEFAULT
+		text = "RULE_OPTION_DEFAULT"
+		desc = "RULE_OPTION_DEFAULT_AI_DESC"
+	}
+	option = {
+		name = OBEDIENCE
+		text = "RULE_OPTION_OBEDIENCE"
+		desc = "RULE_OPTION_OBEDIENCE_MAN_AI_DESC"
+		allow_achievements = yes
+	}
+	option = {
+		name = INDEPENDENCE
+		text = "RULE_OPTION_INDEPENDENCE"
+		desc = "RULE_OPTION_INDEPENDENCE_MAN_AI_DESC"
+	}
+	option = {
+		name = RANDOM
+		text = "RULE_OPTION_RANDOM"
+		desc = "RULE_OPTION_RANDOM_AI_DESC"
+	}
+	option = {
+		name = MAN_MP_1
+		text = "RULE_OPTION_MAN_MP_1"
+		desc = "RULE_OPTION_MAN_MP_1_DESC"
+	}
+	default = {
+		name = MAN_MP_2
+		text = "RULE_OPTION_MAN_MP_2"
+		desc = "RULE_OPTION_MAN_MP_2_AI_DESC"
+	}
+}
+
+ENG_ai_behavior = {
+	name = "ENG_AI_BEHAVIOR"
+	required_dlc = "Man the Guns"
+	group = "RULE_GROUP_AI_BEHAVIOR"
+	option = {
+		name = DEFAULT
+		text = "RULE_OPTION_DEFAULT"
+		desc = "RULE_OPTION_DEFAULT_AI_DESC"
+	}
+	option = {
+		name = DEMOCRATIC_HISTORICAL
+		text = "RULE_OPTION_DEMOCRATIC_HISTORICAL"
+		desc = "RULE_OPTION_DEMOCRATIC_ENG_AI_DESC"
+		allow_achievements = yes
+	}
+	option = {
+		name = DEMOCRATIC_ALTERNATE
+		text = "RULE_OPTION_DEMOCRATIC_NO_MORE_APPEASEMENT"
+		desc = "RULE_OPTION_DEMOCRATIC_NO_MORE_APPEASEMENT_ENG_AI_DESC"
+	}
+	option = {
+		name = COMMUNIST
+		text = "RULE_OPTION_TRADE_UNIONS"
+		desc = "RULE_OPTION_TRADE_UNIONS_ENG_AI_DESC"
+	}
+	option = {
+		name = NEUTRALITY
+		text = "RULE_OPTION_THE_KINGS_PARTY"
+		desc = "RULE_OPTION_THE_KINGS_PARTY_ENG_AI_DESC"
+	}
+	option = {
+		name = FASCIST
+		text = "RULE_OPTION_ORGANIZE_THE_BLACKSHIRTS"
+		desc = "RULE_OPTION_ORGANIZE_THE_BLACKSHIRTS_ENG_AI_DESC"
+	}
+	option = {
+		name = RANDOM
+		text = "RULE_OPTION_RANDOM"
+		desc = "RULE_OPTION_RANDOM_AI_DESC"
+	}
+	default = {
+		name = ENG_MP_1
+		text = "RULE_OPTION_ENG_MP_1"
+		desc = "RULE_OPTION_ENG_MP_1_DESC"
+	}
+}
+
+USA_ai_behavior = {
+	name = "USA_AI_BEHAVIOR"
+	required_dlc = "Man the Guns"
+	group = "RULE_GROUP_AI_BEHAVIOR"
+	option = {
+		name = DEFAULT
+		text = "RULE_OPTION_DEFAULT"
+		desc = "RULE_OPTION_DEFAULT_AI_DESC"
+	}
+	option = {
+		name = COMMUNIST
+		text = "RULE_OPTION_COMMUNIST"
+		desc = "RULE_OPTION_COMMUNIST_USA_AI_DESC"
+	}
+	option = {
+		name = DEMOCRATIC_HISTORICAL
+		text = "RULE_OPTION_DEMOCRATIC_HISTORICAL"
+		desc = "RULE_OPTION_DEMOCRATIC_HISTORICAL_USA_AI_DESC"
+		allow_achievements = yes
+	}
+	option = {
+		name = DEMOCRATIC_ALTERNATE
+		text = "RULE_OPTION_DEMOCRATIC_ALTERNATE"
+		desc = "RULE_DEMOCRATIC_ALTERNATE_USA_AI_DESC"
+	}
+	option = {
+		name = FASCIST
+		text = "RULE_OPTION_FASCIST"
+		desc = "RULE_FASCIST_USA_AI_DESC"
+	}
+	option = {
+		name = RANDOM
+		text = "RULE_OPTION_RANDOM"
+		desc = "RULE_OPTION_RANDOM_AI_DESC"
+	}
+	default = {
+		name = USA_MP_1
+		text = "RULE_OPTION_USA_MP_1"
+		desc = "RULE_OPTION_USA_MP_1_DESC"
+	}
+}
+
+HOL_ai_behavior = {
+	name = "HOL_AI_BEHAVIOR"
+	required_dlc = "Man the Guns"
+	group = "RULE_GROUP_AI_BEHAVIOR"
+	default = {
+		name = DEFAULT
+		text = "RULE_OPTION_DEFAULT"
+		desc = "RULE_OPTION_DEFAULT_AI_DESC"
+	}
+	option = {
+		name = DEMOCRATIC_HISTORICAL
+		text = "RULE_OPTION_DEMOCRATIC_HISTORICAL"
+		desc = "RULE_OPTION_DEMOCRATIC_HISTORICAL_HOL_AI_DESC"
+		allow_achievements = yes
+	}
+	option = {
+		name = DEMOCRATIC_ALTERNATE_1
+		text = "RULE_OPTION_DEMOCRATIC_CONTINUE_THE_WAR_IN_BATAVIA"
+		desc = "RULE_DEMOCRATIC_CONTINUE_THE_WAR_IN_BATAVIA_HOL_AI_DESC"
+	}
+	option = {
+		name = DEMOCRATIC_ALTERNATE_2
+		text = "RULE_OPTION_DEMOCRATIC_CONTINUE_THE_ZUIDERZEE_WORKS"
+		desc = "RULE_DEMOCRATIC_CONTINUE_THE_ZUIDERZEE_WORKS_HOL_AI_DESC"
+	}
+	option = {
+		name = DEMOCRATIC_ALTERNATE_3
+		text = "RULE_OPTION_DEMOCRATIC_LEAD_THE_MINOR_DEMOCRACIES"
+		desc = "RULE_DEMOCRATIC_LEAD_THE_MINOR_DEMOCRACIES_HOL_AI_DESC"
+	}
+	option = {
+		name = COMMUNIST
+		text = "RULE_OPTION_LEGACY_OF_THE_DE_ZEVEN_PROVINCIEN_MUTINY"
+		desc = "RULE_OPTION_LEGACY_OF_THE_DE_ZEVEN_PROVINCIEN_MUTINY_HOL_AI_DESC"
+	}
+	option = {
+		name = NEUTRALITY
+		text = "RULE_OPTION_ORANJE_BOVEN"
+		desc = "RULE_OPTION_ORANJE_BOVEN_HOL_AI_DESC"
+	}
+	option = {
+		name = FASCIST
+		text = "RULE_OPTION_CAVE_TO_THE_GERMANS"
+		desc = "RULE_CAVE_TO_THE_GERMANS_HOL_AI_DESC"
+	}
+	option = {
+		name = RANDOM
+		text = "RULE_OPTION_RANDOM"
+		desc = "RULE_OPTION_RANDOM_AI_DESC"
+	}
+}
+
+MEX_ai_behavior = {
+	name = "MEX_AI_BEHAVIOR"
+	required_dlc = "Man the Guns"
+	group = "RULE_GROUP_AI_BEHAVIOR"
+	default = {
+		name = DEFAULT
+		text = "RULE_OPTION_DEFAULT"
+		desc = "RULE_OPTION_DEFAULT_AI_DESC"
+	}
+	option = {
+		name = SECULAR_REPUBLIC
+		text = "RULE_OPTION_SECULAR_REPUBLIC"
+		desc = "RULE_OPTION_SECULAR_REPUBLIC_DESC"
+		allow_achievements = yes
+	}
+	option = {
+		name = SOCIAL_CATHOLICISM
+		text = "RULE_OPTION_SOCIAL_CATHOLICISM"
+		desc = "RULE_OPTION_SOCIAL_CATHOLICISM_DESC"
+	}
+	option = {
+		name = FASCIST_DICTATORSHIP
+		text = "RULE_OPTION_FASCIST_DICTATORSHIP"
+		desc = "RULE_OPTION_FASCIST_DICTATORSHIP_DESC"
+	}
+	option = {
+		name = THEOCRATIC_ORDER
+		text = "RULE_OPTION_THEOCRATIC_ORDER"
+		desc = "RULE_OPTION_THEOCRATIC_ORDER_DESC"
+	}
+	option = {
+		name = SOVIET_REPUBLIC
+		text = "RULE_OPTION_SOVIET_REPUBLIC"
+		desc = "RULE_OPTION_SOVIET_REPUBLIC_DESC"
+	}
+	option = {
+		name = CARDENISMO
+		text = "RULE_OPTION_CARDENISMO"
+		desc = "RULE_OPTION_CARDENISMO_DESC"
+	}
+	option = {
+		name = RANDOM
+		text = "RULE_OPTION_RANDOM"
+		desc = "RULE_OPTION_RANDOM_AI_DESC"
+	}
+}
+
+SPR_ai_behavior = {
+	name = "SPR_AI_BEHAVIOR"
+	required_dlc = "La Resistance"
+	group = "RULE_GROUP_AI_BEHAVIOR"
+	default = {
+		name = DEFAULT
+		text = "RULE_OPTION_DEFAULT"
+		desc = "RULE_OPTION_DEFAULT_AI_DESC"
+	}
+	option = {
+		name = NATIONALIST_HISTORICAL
+		text = "RULE_OPTION_NATIONALIST_HISTORICAL"
+		desc = "RULE_OPTION_NATIONALIST_HISTORICAL_DESC"
+		allow_achievements = yes
+	}
+	option = {
+		name = SECOND_REPUBLIC
+		text = "RULE_OPTION_SECOND_REPUBLIC"
+		desc = "RULE_OPTION_SECOND_REPUBLIC_DESC"
+	}
+	option = {
+		name = FALANGIST
+		text = "RULE_OPTION_FALANGIST"
+		desc = "RULE_OPTION_FALANGIST_DESC"
+	}
+	option = {
+		name = CARLIST
+		text = "RULE_OPTION_CARLIST"
+		desc = "RULE_OPTION_CARLIST_DESC"
+	}
+	option = {
+		name = ANARCHIST
+		text = "RULE_OPTION_ANARCHIST"
+		desc = "RULE_OPTION_ANARCHIST_DESC"
+	}
+	option = {
+		name = INDEPENDENT_COMMUNIST
+		text = "RULE_OPTION_INDEPENDENT_COMMUNIST"
+		desc = "RULE_OPTION_INDEPENDENT_COMMUNIST_DESC"
+	}
+	option = {
+		name = STALINIST
+		text = "RULE_OPTION_STALINIST"
+		desc = "RULE_OPTION_STALINIST_DESC"
+	}
+	option = {
+		name = RANDOM
+		text = "RULE_OPTION_RANDOM"
+		desc = "RULE_OPTION_RANDOM_AI_DESC"
+	}
+}
+
+POR_ai_behavior = {
+	name = "POR_AI_BEHAVIOR"
+	required_dlc = "La Resistance"
+	group = "RULE_GROUP_AI_BEHAVIOR"
+	default = {
+		name = DEFAULT
+		text = "RULE_OPTION_DEFAULT"
+		desc = "RULE_OPTION_DEFAULT_AI_DESC"
+	}
+	option = {
+		name = HISTORICAL
+		text = "RULE_OPTION_HISTORICAL"
+		desc = "RULE_OPTION_HISTORICAL_POR_AI_DESC"
+		allow_achievements = yes
+	}
+	option = {
+		name = FASCIST
+		text = "RULE_OPTION_FASCIST"
+		desc = "RULE_OPTION_FASCIST_POR_AI_DESC"
+	}
+	option = {
+		name = FASCIST_FIFTH_EMPIRE
+		text = "RULE_OPTION_FASCIST_FIFTH_EMPIRE"
+		desc = "RULE_OPTION_FASCIST_FIFTH_EMPIRE_DESC"
+	}
+	option = {
+		name = NEUTRALITY_MONARCHIST
+		text = "RULE_OPTION_NEUTRALITY_MONARCHIST"
+		desc = "RULE_OPTION_NEUTRALITY_MONARCHIST_DESC"
+	}
+	option = {
+		name = DEMOCRATIC
+		text = "RULE_OPTION_DEMOCRATIC"
+		desc = "RULE_OPTION_DEMOCRATIC_POR_AI_DESC"
+	}
+	option = {
+		name = COMMUNIST_COMINTERN
+		text = "RULE_OPTION_COMMUNIST_COMINTERN"
+		desc = "RULE_OPTION_COMMUNIST_COMINTERN_DESC"
+	}
+	option = {
+		name = COMMUNIST_INDEPENDENT
+		text = "RULE_OPTION_COMMUNIST_INDEPENDENT"
+		desc = "RULE_OPTION_COMMUNIST_INDEPENDENT_DESC"
+	}
+	option = {
+		name = RANDOM
+		text = "RULE_OPTION_RANDOM"
+		desc = "RULE_OPTION_RANDOM_AI_DESC"
+	}
+}
+
+ETH_ai_behavior = {
+	name = "ETH_AI_BEHAVIOR"
+	group = "RULE_GROUP_AI_BEHAVIOR"
+	option = {
+		name = DEFAULT
+		text = "RULE_OPTION_DEFAULT"
+		desc = "RULE_OPTION_DEFAULT_AI_DESC"
+	}
+	default = {
+		name = ETH_MP_1
+		text = "RULE_OPTION_ETH_MP_1"
+		desc = "RULE_OPTION_ETH_MP_1_DESC"
+	}
+}
+
+SIA_ai_behavior = {
+	name = "SIA_AI_BEHAVIOR"
+	group = "RULE_GROUP_AI_BEHAVIOR"
+	option = {
+		name = DEFAULT
+		text = "RULE_OPTION_DEFAULT"
+		desc = "RULE_OPTION_DEFAULT_AI_DESC"
+	}
+	default = {
+		name = SIA_MP_1
+		text = "RULE_OPTION_SIA_MP_1"
+		desc = "RULE_OPTION_SIA_MP_1_DESC"
+	}
+}
+
+MAL_ai_behavior = {
+	name = "MAL_AI_BEHAVIOR"
+	group = "RULE_GROUP_AI_BEHAVIOR"
+	option = {
+		name = DEFAULT
+		text = "RULE_OPTION_DEFAULT"
+		desc = "RULE_OPTION_DEFAULT_AI_DESC"
+	}
+	option = {
+		name = MAL_MP_1
+		text = "RULE_OPTION_MAL_MP_1"
+		desc = "RULE_OPTION_MAL_MP_1_DESC"
+	}
+	default = {
+		name = MAL_MP_2
+		text = "RULE_OPTION_MAL_MP_2"
+		desc = "RULE_OPTION_MAL_MP_2_DESC"
+	}
+}
+
+INS_ai_behavior = {
+	name = "INS_AI_BEHAVIOR"
+	group = "RULE_GROUP_AI_BEHAVIOR"
+	option = {
+		name = DEFAULT
+		text = "RULE_OPTION_DEFAULT"
+		desc = "RULE_OPTION_DEFAULT_AI_DESC"
+	}
+	default = {
+		name = INS_MP_1
+		text = "RULE_OPTION_INS_MP_1"
+		desc = "RULE_OPTION_INS_MP_1_DESC"
+	}
+}
+
+ALB_ai_behavior = {
+	name = "ALB_AI_BEHAVIOR"
+	group = "RULE_GROUP_AI_BEHAVIOR"
+	option = {
+		name = DEFAULT
+		text = "RULE_OPTION_DEFAULT"
+		desc = "RULE_OPTION_DEFAULT_AI_DESC"
+	}
+	default = {
+		name = ALB_MP_1
+		text = "RULE_OPTION_ALB_MP_1"
+		desc = "RULE_OPTION_ALB_MP_1_DESC"
+	}
+}
+
+MEN_ai_behavior = {
+	name = "MEN_AI_BEHAVIOR"
+	group = "RULE_GROUP_AI_BEHAVIOR"
+	option = {
+		name = DEFAULT
+		text = "RULE_OPTION_DEFAULT"
+		desc = "RULE_OPTION_DEFAULT_AI_DESC"
+	}
+	default = {
+		name = MEN_MP_1
+		text = "RULE_OPTION_MEN_MP_1"
+		desc = "RULE_OPTION_MEN_MP_1_DESC"
+	}
+}
+
+MON_ai_behavior = {
+	name = "MON_AI_BEHAVIOR"
+	group = "RULE_GROUP_AI_BEHAVIOR"
+	option = {
+		name = DEFAULT
+		text = "RULE_OPTION_DEFAULT"
+		desc = "RULE_OPTION_DEFAULT_AI_DESC"
+	}
+	default = {
+		name = MON_MP_1
+		text = "RULE_OPTION_MON_MP_1"
+		desc = "RULE_OPTION_MON_MP_1_DESC"
+	}
+}

--- a/events/LAR_occupation.txt
+++ b/events/LAR_occupation.txt
@@ -1,0 +1,322 @@
+﻿
+add_namespace = occupied_countries
+
+#instantiate a collabration government
+country_event = {
+	id = occupied_countries.1
+	title = occupied_countries.1.title
+	desc = occupied_countries.1.desc
+	
+	# todo lar
+	picture = GFX_report_event_canadian_soldiers
+	
+	is_triggered_only = yes
+
+	option = {
+		name = occupied_countries.1.a
+
+		ai_chance = {
+			base = 0
+		}
+		
+		if = {
+			limit = {
+				has_core_occupation_modifier = {
+					occupied_country_tag = FROM.FROM
+					modifier = compliance_80
+				}
+				NOT = {
+					any_country_with_original_tag = { #copy of is_available_to_collaboration_government but from from scope because of events
+						original_tag_to_check = FROM.FROM
+						is_puppet_of = PREV # if already created one do not create another
+						has_autonomy_state = autonomy_collaboration_government
+					}
+				}
+			}
+			set_temp_variable = { country_to_initiate = FROM.FROM }
+			instantiate_collaboration_government = yes
+		}
+	}
+
+	option = {
+		name = occupied_countries.1.b
+		# do nothing
+		ai_chance = {
+			base = 100
+		}
+	}
+}
+
+
+# create uprising
+country_event = {
+	id = occupied_countries.2
+	
+	is_triggered_only = yes
+	
+	hidden = yes
+	
+	immediate = {
+		FROM = {
+			if = {
+				limit = {
+					has_core_occupation_modifier = {
+						occupied_country_tag = FROM
+						modifier = resistance_90
+					}
+				}
+				
+				set_temp_variable = { occupier_country = THIS }
+				set_temp_variable = { occupied_country = FROM }
+				set_temp_variable = { new_occupied_country = FROM }
+				
+				if = { #warsaw achievement
+					limit = {
+						var:occupied_country = { original_tag = POL }
+					}
+					set_global_flag = warsaw_liberated_self_flag
+				}
+				
+				
+				set_temp_variable = { civil_war_country_picked = 0 }
+				if = {
+					## pick an existing civil war country
+					limit = {
+						FROM = {
+							tag = PREV
+						}
+					}
+					
+					random_country_with_original_tag = {
+						original_tag_to_check = var:occupier_country
+						
+						limit = {
+							NOT = { tag = var:occupier_country }
+							has_war_with = var:occupier_country
+						}
+						
+						set_temp_variable = { civil_war_country_picked = 1 }
+						set_temp_variable = { new_occupied_country = this }
+					}
+				}
+				
+				if = {
+					## create a new country if necesarry
+					limit = {
+						check_variable = { civil_war_country_picked = 0 } 
+						FROM = {
+							#if resistance country exists and not at war with occupier (whitepaced/subjected etc) create a country instead
+							exists = yes
+							NOT = { has_war_with = occupier_country }
+						}
+					}
+					create_dynamic_country = {
+						original_tag = FROM
+						copy_tag = FROM
+						
+						set_temp_variable = { new_occupied_country = THIS }
+					}
+				}
+				
+				
+				# change ideology if necessary
+				if = {
+					limit = { 
+						var:occupied_country = {
+							#only change ideology if we are not creating a new country and old country is not existing
+							OR = {
+								exists = no
+								NOT = { tag = new_occupied_country }
+							}
+						}
+					}
+					
+					# booleans that will be allowed to change ideology
+					set_temp_variable = { allowed_party_neutrality = 1 }
+					set_temp_variable = { allowed_party_democratic = 1 }
+					set_temp_variable = { allowed_party_fascism = 1 }
+					set_temp_variable = { allowed_party_communism = 1 }
+					
+					# do not change ideology of occupier country
+					var:occupier_country = {
+						remove_from_allowed_party = yes
+					}
+					
+					if = {
+						# if occupied country exists and different than new country
+						# it is white peaced & subject of occupier. ignore its ideology as well
+						limit = { NOT = { check_variable = { new_occupied_country = occupied_country } } }
+						var:occupied_country = {
+							remove_from_allowed_party = yes
+						}
+					}
+					
+					# change government if necesarry
+					var:new_occupied_country = {
+						if = {
+							# check if our current ideology is OK
+							limit = { 
+								OR = {
+									AND = {
+										has_government = democratic
+										check_variable = { allowed_party_democratic = 0 }
+									}
+									AND = {
+										has_government = fascism
+										check_variable = { allowed_party_fascism = 0 }
+									}
+									AND = {
+										has_government = communism
+										check_variable = { allowed_party_communism = 0 }
+									}
+									AND = { 
+										has_government = neutrality
+										check_variable = { allowed_party_neutrality = 0 }
+									}
+								}
+							}
+							
+							random_list = {
+								allowed_party_democratic = {
+									set_popularities = {
+										democratic = 100
+									}
+									set_politics = { ruling_party = democratic elections_allowed = yes }
+								}
+								allowed_party_fascism = {
+									set_popularities = {
+										fascism = 100
+									}
+									set_politics = { ruling_party = fascism elections_allowed = no }
+								}
+								allowed_party_communism = {
+									set_popularities = {
+										communism = 100
+									}
+									set_politics = { ruling_party = communism elections_allowed = no }
+								}
+								allowed_party_neutrality = {
+									set_popularities = {
+										neutrality = 100
+									}
+									set_politics = { ruling_party = neutrality elections_allowed = no }
+								}
+							}
+						}
+					}
+				}
+				
+				# create resistance template for armies to spawn
+				var:new_occupied_country = {
+					if = {
+						limit = { NOT = { has_country_flag = created_civil_war_template } }
+						set_country_flag = created_civil_war_template
+							
+						division_template = {
+							name = "Resistance"
+							is_locked = yes
+							regiments = {
+								infantry = { x = 0 y = 0 }
+								infantry = { x = 0 y = 1 }
+					
+								infantry = { x = 1 y = 0 }
+								infantry = { x = 1 y = 1 }
+								
+								infantry = { x = 2 y = 0 }
+								infantry = { x = 2 y = 1 }
+							}
+						}
+					}
+				}
+				
+				
+				clear_temp_array = checked_neighbours
+				every_controlled_state = {
+					limit = { occupied_country_tag = occupied_country }
+					
+					# move our armies to back home
+					teleport_armies = {
+						limit = { 
+							OR = {
+								is_ally_with = occupier_country
+								has_military_access_to = occupier_country
+							}
+						}
+						to_state_array = owned_controlled_states
+					}
+					
+					# transfer state
+					if = {
+						limit = { has_resistance = yes }
+						set_resistance = 0
+					}
+					var:new_occupied_country = {
+						transfer_state = PREV
+					}
+					
+					if = {
+						limit = { 
+							var:occupier_country = {
+								check_variable = { resistance_already_inited@var:occupied_country = 0 } 
+							}
+						}
+						
+						# create resistance units, number is relative to size of industry
+						set_temp_variable = { num_units_to_create = building_level@arms_factory }
+						add_to_temp_variable = { num_units_to_create = building_level@industrial_complex } 
+						divide_temp_variable = { num_units_to_create = 3 }
+						add_to_temp_variable = { num_units_to_create = 2 }
+						round_temp_variable = num_units_to_create
+						clamp_temp_variable = { var = num_units_to_create min = 2 max = 6 }
+						for_loop_effect = {
+							end = num_units_to_create
+							
+							create_unit = {
+								division = "division_template = \"Resistance\" start_experience_factor = 1 start_equipment_factor = 1"
+								owner = new_occupied_country
+							}
+						}
+					}
+					
+					# also check neighbouring core states of the occupier that are not captured yet
+					# move our armies so they are not surrounded/create pockets
+					every_neighbor_state = {
+						limit = {
+							is_owned_and_controlled_by = occupied_country
+							is_core_of = occupied_country
+							not = { is_in_array = { checked_neighbours = this } }
+						}
+						add_to_temp_array = { checked_neighbours = this }
+						
+						teleport_armies = {
+							limit = { 
+								OR = {
+									is_ally_with = occupier_country
+									has_military_access_to = occupier_country
+								}
+							}
+							to_state_array = owned_controlled_states
+						}
+						
+						set_state_province_controller = {
+							controller = occupied_country
+							limit = {
+								is_ally_with = occupier_country
+							}
+						}
+					}
+				}
+			
+				# create war if necesarry
+				if = {
+					limit = { NOT = { has_war_with = new_occupied_country } }
+					declare_war_on = { target = new_occupied_country type = annex_everything }
+				}
+				
+				var:occupier_country = {
+					set_variable = { resistance_already_inited@var:occupied_country = 1 } 
+				}
+			
+			}
+		}
+	}


### PR DESCRIPTION
Ported AI_scripts from my mod to IHMP.
Removed Fighter 3 research rush for Mongolia, Siam and Australia
Removed Heavy Tank research rush from Bulgaria and Malaysia
Removed war with Greece Focus from the Italian Focus list
Added second_vinson_award focus for USA

Additionally I attached a game_rule file with only the AI_Behaviour entries, which are used by the scripts to enable them.

Info:
CHI_default_strategy_plan.txt is added to overwrite the existing file.
Changed that if the befriend Majors for the shared Chinese FocusTree script from there is only used if not a ai_script of mine is activated. I added my own, improved befriend script.

CHI_warlord_historical_strategy_plan.txt is added to overwrite the existing file.
This was the only vanilla script that asked for historical_focus = yes, instead of plan_setting. Changed it, so it only loads if the "DEFAULT" ai_setting is picked on startup.

Notes to further improve the AI:
These scripts improve Focus Picks, Construction Order, PP spending and sometimes war material production.
To further improve ai, especially for France, Poland and China, I suggest adding new ai_templates for them.

the ai_strategy (not script the outright always active ai_strategy) for Hungary blocks joining Germany until later. It also gives China a ignore_army_incompetence modifier. I suggest removing both, by overwriting vanilla files.

Poland and France have spy_agency ai_strategies added, but they are only active, if that isn't overwritten by Vanilla ai_will_do in intelligence_agency_upgrades file.

Finally, you know my economic event files. Changing to early/partial mobilisation as soon as the ai is allowed to do from game mechanics help them alot. I suggest either adding those events, or changing the defines, so with enough priority the ai change the economic laws themselfs, without the events.