### PR TITLE
Added historical_focus modifier 0 to chinese event options

### DIFF
--- a/events/WTT_China.txt
+++ b/events/WTT_China.txt
@@ -1,0 +1,2021 @@
+﻿add_namespace = wtt_china
+
+#
+
+# China demands warlord be puppeted
+country_event = {
+	id = wtt_china.1
+	title = wtt_china.1.t
+	desc = wtt_china.1.desc
+	picture = GFX_report_event_chinese_officers
+
+	is_triggered_only = yes
+	
+	#Accept puppet
+	option = {
+		name = wtt_china.1.a
+		ai_chance = { 
+			base = 10 
+			modifier = {
+				has_global_flag = CHI_xian_refused
+				factor = 0
+			}
+		}
+		FROM = {
+			puppet = ROOT
+			country_event = { id = wtt_china.2 }
+		}
+	}
+
+	#Never
+	option = {
+		name = wtt_china.1.b
+		ai_chance = { 
+			base = 10 
+		}
+		FROM = {
+			country_event = { id = wtt_china.3 }
+		}
+	}
+}
+
+# Answer from warlord china.1 - Yes
+country_event = {
+	id = wtt_china.2
+	title = wtt_china.2.t
+	desc = wtt_china.2.desc
+	picture = GFX_report_event_chinese_japanese_handshake
+
+	is_triggered_only = yes
+	
+	option = {
+		name = wtt_china.2.a
+	}
+}
+
+
+# Answer from warlord china.1 - No
+country_event = {
+	id = wtt_china.3
+	title = wtt_china.3.t
+	desc = wtt_china.3.desc
+	picture = GFX_report_event_chinese_soldiers_01
+
+	is_triggered_only = yes
+	
+	option = {
+		name = wtt_china.3.a
+		create_wargoal = {
+				type = puppet_wargoal_focus
+				target = FROM
+		}
+	}
+}
+
+
+
+# China demands ROOT be puppeted
+country_event = {
+	id = wtt_china.10
+	title = wtt_china.10.t
+	desc = wtt_china.10.desc
+	picture = GFX_report_event_chinese_soldiers
+
+	is_triggered_only = yes
+	
+	#Accept puppet
+	option = {
+		name = wtt_china.10.a
+		ai_chance = { base = 10 }
+		FROM = {
+			puppet = ROOT
+			country_event = { id = wtt_china.11 }
+		}
+	}
+	option = {
+
+		name = wtt_china.10.b
+		ai_chance = {
+			base = 10
+			modifier = {
+				tag = JAP
+				add = 80 #TODO_WTT_AI script modifiers for how likely people are to accept puppeting
+			}
+			modifier = {
+				tag = TIB
+				add = 30 #TODO_WTT_AI script modifiers for how likely people are to accept puppeting
+			}
+			modifier = {
+				tag = MON
+				add = 30 #TODO_WTT_AI script modifiers for how likely people are to accept puppeting
+			}
+		}
+		FROM = {
+			create_wargoal = {
+				type = puppet_wargoal_focus
+				target = ROOT
+			}
+			country_event = { id = wtt_china.12 }
+		}
+	}
+}
+
+# Answer from ROOT china.10 - Yes
+country_event = {
+	id = wtt_china.11
+	title = wtt_china.11.t
+	desc = wtt_china.11.desc
+	picture = GFX_report_event_chinese_japanese_handshake
+
+	is_triggered_only = yes
+	
+	option = {
+		name = wtt_china.11.a
+	}
+}
+
+
+# Answer from ROOT china.10 - No
+country_event = {
+	id = wtt_china.12
+	title = wtt_china.12.t
+	desc = wtt_china.12.desc
+	picture = GFX_report_event_chinese_soldiers_01
+
+	is_triggered_only = yes
+	
+	option = {
+		name = wtt_china.12.a
+	}
+}
+
+ ##  #  # ### ###  ###  ### #   #    ##      ### #  # ### ### #   ### ###   ##  ### ###  ##  #  # 
+#    #  # #   #  # #  #  #  #   #   #  #      #  ## # #    #  #    #  #  # #  #  #   #  #  # ## # 
+# ## #  # ##  ###  ###   #  #   #   ####      #  # ## ##   #  #    #  ###  ####  #   #  #  # # ## 
+#  # #  # #   #  # #  #  #  #   #   #  #      #  #  # #    #  #    #  #  # #  #  #   #  #  # #  # 
+ ##   ##  ### #  # #  # ### ### ### #  #     ### #  # #   ### ###  #  #  # #  #  #  ###  ##  #  # 
+
+add_namespace = wtt_infiltration
+
+#Hidden event that check for infiltration and successful detection approximately monthly
+country_event = {
+	id = wtt_infiltration.1
+	title = wtt_infiltration.1.t
+	desc = wtt_china.1.desc
+	picture = GFX_report_event_indian_soldiers 
+
+	hidden = yes
+	mean_time_to_happen = {
+		days = 30
+	}
+
+	trigger = {
+		tag = event_target:WTT_current_china_leader
+		any_other_country = {
+			has_completed_focus = PRC_infiltration
+			has_government = communism
+		}
+	}
+	
+	immediate = {
+		every_controlled_state = { 
+			limit = {
+				has_any_PRC_infiltration_flag = yes
+				NOT = { has_state_flag = discovered_infiltration }
+			}
+			random_list = {
+				10 = { 
+					set_state_flag = discovered_infiltration
+					save_event_target_as = infiltrated_state
+
+					if = {
+						limit = { state = 615 }
+						ROOT = { country_event = wtt_infiltration.615 }
+					}	
+					else_if = {
+						limit = { state = 621 }
+						ROOT = { country_event = wtt_infiltration.621 }
+					}	
+					else_if = {
+						limit = { state = 608 }
+						ROOT = { country_event = wtt_infiltration.608 }
+					}	
+					else_if = {
+						limit = { state = 614 }
+						ROOT = { country_event = wtt_infiltration.614 }
+					}	
+					else_if = {
+						limit = { state = 597 }
+						ROOT = { country_event = wtt_infiltration.597 }
+					}	
+					else_if = {
+						limit = { state = 598 }
+						ROOT = { country_event = wtt_infiltration.598 }
+					}	
+					else_if = {
+						limit = { state = 607 }
+						ROOT = { country_event = wtt_infiltration.607 }
+					}
+					else_if = {
+						limit = { state = 283 }
+						ROOT = { country_event = wtt_infiltration.283 }
+					}
+					else_if = {
+						limit = { state = 744 }
+						ROOT = { country_event = wtt_infiltration.744 }
+					}
+					else_if = {
+						limit = { state = 746 }
+						ROOT = { country_event = wtt_infiltration.746 }
+					}
+
+					set_global_flag = new_infiltration_detected
+					if = {
+						limit = { 
+							ROOT = { NOT = { has_country_flag = CHI_first_infiltration_discovered } }
+						}
+						ROOT = { set_country_flag = CHI_first_infiltration_discovered }
+					}
+					if = {
+						limit = {
+							ROOT = { has_country_flag = CHI_clean_sweep }
+						}
+						ROOT = { clr_country_flag = CHI_clean_sweep }
+					}
+				}
+				90 = {
+					#Nothing happens
+				}
+			}
+		}
+
+		if = {
+			limit = {
+				NOT = { has_global_flag = new_infiltration_detected }
+			}
+			if = {
+				limit = { ROOT_any_state_infiltration_detected = yes }
+				country_event = wtt_infiltration.3
+				else_if = {
+					limit = { 
+						has_country_flag = CHI_first_infiltration_discovered 
+						NOT = { has_country_flag = CHI_clean_sweep }
+					}
+					#No infiltrations discovered
+					country_event = wtt_infiltration.4
+				}
+			}
+		}
+		clr_global_flag = new_infiltration_detected
+	}
+}
+# notification event for infiltrator that cell has been removed
+country_event = {
+	id = wtt_infiltration.6
+	title = wtt_infiltration.6.t
+	desc = wtt_infiltration.6.desc
+	picture = GFX_report_event_dead_soldiers
+
+	is_triggered_only = yes
+
+	option = {
+		name = wtt_infiltration.6.a
+	}
+
+}
+
+#Have to make one for each state because only 1 instance of the event is allowed in the window
+#Infiltration detected in state - TODO_WTT_CD could chose to make description based on what type of infiltration is present.
+country_event = {
+	id = wtt_infiltration.615
+	title = wtt_infiltration.2.t
+	desc = wtt_infiltration.2.desc
+	picture = GFX_report_event_china_infiltration
+
+	is_triggered_only = yes
+	
+	option = {
+		name = wtt_infiltration.2.a
+	}
+}
+
+country_event = {
+	id = wtt_infiltration.621
+	title = wtt_infiltration.2.t
+	desc = wtt_infiltration.2.desc
+	picture = GFX_report_event_china_infiltration
+
+	is_triggered_only = yes
+	
+	option = {
+		name = wtt_infiltration.2.a
+	}
+}
+
+country_event = {
+	id = wtt_infiltration.608
+	title = wtt_infiltration.2.t
+	desc = wtt_infiltration.2.desc
+	picture = GFX_report_event_china_infiltration
+
+	is_triggered_only = yes
+	
+	option = {
+		name = wtt_infiltration.2.a
+	}
+}
+
+country_event = {
+	id = wtt_infiltration.614
+	title = wtt_infiltration.2.t
+	desc = wtt_infiltration.2.desc
+	picture = GFX_report_event_china_infiltration
+
+	is_triggered_only = yes
+	
+	option = {
+		name = wtt_infiltration.2.a
+	}
+}
+
+country_event = {
+	id = wtt_infiltration.597
+	title = wtt_infiltration.2.t
+	desc = wtt_infiltration.2.desc
+	picture = GFX_report_event_china_infiltration
+
+	is_triggered_only = yes
+	
+	option = {
+		name = wtt_infiltration.2.a
+	}
+}
+
+
+
+country_event = {
+	id = wtt_infiltration.598
+	title = wtt_infiltration.2.t
+	desc = wtt_infiltration.2.desc
+	picture = GFX_report_event_china_infiltration
+
+	is_triggered_only = yes
+	
+	option = {
+		name = wtt_infiltration.2.a
+	}
+}
+
+country_event = {
+	id = wtt_infiltration.607
+	title = wtt_infiltration.2.t
+	desc = wtt_infiltration.2.desc
+	picture = GFX_report_event_china_infiltration
+
+	is_triggered_only = yes
+	
+	option = {
+		name = wtt_infiltration.2.a
+	}
+}
+
+country_event = {
+	id = wtt_infiltration.283
+	title = wtt_infiltration.2.t
+	desc = wtt_infiltration.2.desc
+	picture = GFX_report_event_china_infiltration
+
+	is_triggered_only = yes
+	
+	option = {
+		name = wtt_infiltration.2.a
+	}
+}
+
+country_event = {
+	id = wtt_infiltration.744
+	title = wtt_infiltration.2.t
+	desc = wtt_infiltration.2.desc
+	picture = GFX_report_event_china_infiltration
+
+	is_triggered_only = yes
+	
+	option = {
+		name = wtt_infiltration.2.a
+	}
+}
+
+country_event = {
+	id = wtt_infiltration.746
+	title = wtt_infiltration.2.t
+	desc = wtt_infiltration.2.desc
+	picture = GFX_report_event_china_infiltration
+
+	is_triggered_only = yes
+	
+	option = {
+		name = wtt_infiltration.2.a
+	}
+}
+
+
+#Event for nationalists
+#No infiltration detected but still some detected in the country
+country_event = {
+	id = wtt_infiltration.3
+	title = wtt_infiltration.3.t
+	desc = wtt_infiltration.3.desc
+	picture = GFX_report_event_chinese_officers
+
+	is_triggered_only = yes
+	
+	option = {
+		name = wtt_infiltration.3.a
+	}
+}
+
+#Event for nationalists
+#No infiltration detected NONE detected in entire country
+country_event = {
+	id = wtt_infiltration.4
+	title = wtt_infiltration.4.t
+	desc = wtt_infiltration.4.desc
+	picture = GFX_report_event_chinese_soldiers
+
+	is_triggered_only = yes
+
+	immediate = {
+		hidden_effect = {
+			set_country_flag = CHI_clean_sweep
+		}
+	}
+	
+	option = {
+		name = wtt_infiltration.4.a
+	}
+}
+
+#Event for nationalists
+#Warning that uprising is coming
+country_event = {
+	id = wtt_infiltration.10
+	title = wtt_infiltration.10.t
+	desc = wtt_infiltration.10.desc
+	picture = GFX_report_event_chinese_soldiers_running
+
+	is_triggered_only = yes
+	
+	option = {
+		name = wtt_infiltration.10.a
+	}
+}
+
+ ##  #  # ### ###   ####  ##  ##   ##  #  #
+#  # ## #  #   #       # #  # # # #  # ## #
+#### # ##  #   #    #  # #### ##  #### # ##
+#  # #  #  #  ###    ##  #  # #   #  # #  #
+
+#Infiltration for MAN and MEN states
+#Hidden event that check for infiltration and successful detection approximately monthly
+country_event = {
+	id = wtt_infiltration.20
+
+	hidden = yes
+	mean_time_to_happen = {
+		days = 30
+	}
+
+	trigger = {
+		OR = {
+			609 = {
+				is_controlled_by_ROOT_or_subject = yes
+			}
+			610 = {
+				is_controlled_by_ROOT_or_subject = yes
+			}
+			611 = {
+				is_controlled_by_ROOT_or_subject = yes
+			}
+			612 = {
+				is_controlled_by_ROOT_or_subject = yes
+			}
+			714 = {
+				is_controlled_by_ROOT_or_subject = yes
+			}
+			715 = {
+				is_controlled_by_ROOT_or_subject = yes
+			}
+		}
+		any_other_country = {
+			has_completed_focus = PRC_anti_japanese_expedition
+			has_government = communism
+			not = { is_in_faction_with = ROOT }
+		}		
+	}
+	
+	immediate = {
+		every_state = { ##WTT_TODO_CD We have to do this per state atm. Can only have 1 instance of an event in window
+			limit = {
+				CONTROLLER = {
+					OR = {
+						is_subject_of = ROOT
+						tag = ROOT
+					}
+				}
+				has_any_PRC_infiltration_flag = yes
+				NOT = { has_state_flag = discovered_infiltration }
+			}
+			random_list = {
+				10 = { #TODO_WTT_CD change chance
+					set_state_flag = discovered_infiltration
+					save_event_target_as = infiltrated_state
+
+					if = {
+						limit = { state = 609 }
+						ROOT = {
+							if = {
+								limit = { is_subject = yes }
+								OVERLORD = { country_event = wtt_infiltration.609 }
+							}
+							else = { country_event = wtt_infiltration.609 }
+						}
+					} 
+					if = {
+						limit = { state = 610 }
+						ROOT = {
+							if = {
+								limit = { is_subject = yes }
+								OVERLORD = { country_event = wtt_infiltration.610 }
+							}
+							else = { country_event = wtt_infiltration.610 }
+						}
+					} 
+					if = {
+						limit = { state = 611 }
+						ROOT = {
+							if = {
+								limit = { is_subject = yes }
+								OVERLORD = { country_event = wtt_infiltration.611 }
+							}
+							else = { country_event = wtt_infiltration.611 }
+						}
+					} 
+					if = {
+						limit = { state = 612 }
+						ROOT = {
+							if = {
+								limit = { is_subject = yes }
+								OVERLORD = { country_event = wtt_infiltration.612 }
+							}
+							else = { country_event = wtt_infiltration.612 }
+						}
+					} 
+					if = {
+						limit = { state = 714 }
+						ROOT = {
+							if = {
+								limit = { is_subject = yes }
+								OVERLORD = { country_event = wtt_infiltration.714 }
+							}
+							else = { country_event = wtt_infiltration.714 }
+						}
+					} 
+					if = {
+						limit = { state = 715 }
+						ROOT = {
+							if = {
+								limit = { is_subject = yes }
+								OVERLORD = { country_event = wtt_infiltration.715 }
+							}
+							else = { country_event = wtt_infiltration.715 }
+						}
+					}
+					set_global_flag = new_infiltration_detected
+					if = {
+						limit = { 
+							ROOT = { 
+								NOT = { has_country_flag = PRC_anti_japanese_first_detection } 
+							} 
+						}
+						ROOT = { set_country_flag = PRC_anti_japanese_first_detection }
+					}
+					if = {
+						limit = { 
+							ROOT = { has_country_flag = PRC_anti_japanese_clean_sweep }
+						}
+						ROOT = { clr_country_flag = PRC_anti_japanese_clean_sweep }
+					}
+				}
+				0 = {
+					#Nothing happens
+				}
+			}
+		}
+
+		if = {
+			limit = {
+				NOT = { has_global_flag = new_infiltration_detected }
+			}
+			if = {
+				limit = { ROOT_any_anti_JAP_state_infiltration_detected = yes }
+				country_event = wtt_infiltration.23
+				else_if = {
+					limit = { 
+						has_country_flag = PRC_anti_japanese_first_detection
+						NOT = { has_country_flag = PRC_anti_japanese_clean_sweep }
+					}
+					#No infiltrations discovered
+					country_event = wtt_infiltration.24
+				}
+			}
+		}
+		clr_global_flag = new_infiltration_detected
+	}
+}
+
+#No infiltration detected but still some detected in the country
+country_event = {
+	id = wtt_infiltration.23
+	title = wtt_infiltration.23.t
+	desc = wtt_infiltration.23.desc
+	picture = GFX_report_event_manchukuo_army
+
+	is_triggered_only = yes
+	
+	option = {
+		name = wtt_infiltration.23.a
+	}
+}
+
+#No infiltration detected NONE detected in entire country
+country_event = {
+	id = wtt_infiltration.24
+	title = wtt_infiltration.24.t
+	desc = wtt_infiltration.24.desc
+	picture = GFX_report_event_manchukuo_army_2
+
+	is_triggered_only = yes
+	immediate = {
+		hidden_effect = {
+			if = {
+				limit = {
+					NOT = { has_country_flag = PRC_anti_japanese_clean_sweep }
+				}
+				set_country_flag = PRC_anti_japanese_clean_sweep
+			}
+		}
+	}
+	option = {
+		name = wtt_infiltration.24.a
+	}
+}
+
+country_event = {
+	id = wtt_infiltration.609
+	title = wtt_infiltration.21.t
+	desc = wtt_infiltration.21.desc
+	picture = GFX_report_event_china_infiltration
+
+	is_triggered_only = yes
+	
+	option = {
+		name = wtt_infiltration.21.a
+	}
+}
+
+country_event = {
+	id = wtt_infiltration.610
+	title = wtt_infiltration.21.t
+	desc = wtt_infiltration.21.desc
+	picture = GFX_report_event_china_infiltration
+
+	is_triggered_only = yes
+	
+	option = {
+		name = wtt_infiltration.21.a
+	}
+}
+
+country_event = {
+	id = wtt_infiltration.611
+	title = wtt_infiltration.21.t
+	desc = wtt_infiltration.21.desc
+	picture = GFX_report_event_china_infiltration
+
+	is_triggered_only = yes
+	
+	option = {
+		name = wtt_infiltration.21.a
+	}
+}
+
+country_event = {
+	id = wtt_infiltration.612
+	title = wtt_infiltration.21.t
+	desc = wtt_infiltration.21.desc
+	picture = GFX_report_event_china_infiltration
+
+	is_triggered_only = yes
+	
+	option = {
+		name = wtt_infiltration.21.a
+	}
+}
+
+country_event = {
+	id = wtt_infiltration.714
+	title = wtt_infiltration.21.t
+	desc = wtt_infiltration.21.desc
+	picture = GFX_report_event_china_infiltration
+
+	is_triggered_only = yes
+	
+	option = {
+		name = wtt_infiltration.21.a
+	}
+}
+
+country_event = {
+	id = wtt_infiltration.715
+	title = wtt_infiltration.21.t
+	desc = wtt_infiltration.21.desc
+	picture = GFX_report_event_china_infiltration
+
+	is_triggered_only = yes
+	
+	option = {
+		name = wtt_infiltration.21.a
+	}
+}
+
+add_namespace = wtt_xian_incident
+
+#Xian incident - should Chiang go?
+country_event = {
+	id = wtt_xian_incident.1
+	title = wtt_xian_incident.1.t
+	desc = wtt_xian_incident.1.desc
+	picture = GFX_report_event_china_politicians_captured
+
+	is_triggered_only = yes #triggered by warlord decision
+
+	immediate = {
+		hidden_effect = {
+			random_other_country = {
+				limit = {
+					has_country_flag = CHI_xian_instigator_flag
+				}
+				save_event_target_as = CHI_xian_instigator
+			}
+		}
+	}
+	
+	option = {
+		name = wtt_xian_incident.1.a #agree to go
+		ai_chance = {
+			base = 70
+		}
+		event_target:CHI_xian_instigator = { country_event = wtt_xian_incident.2 }
+	}
+	option = {
+		name = wtt_xian_incident.1.b #refuse to go
+		custom_effect_tooltip = CHI_xian_warlords_upset
+		ai_chance = {
+			base = 30
+			modifier = {
+				CHI_is_on_historical_plan_trigger = yes
+				factor = 0
+			}
+			modifier = {
+				is_historical_focus_on = yes
+				factor = 0
+			}
+		}
+		event_target:CHI_xian_instigator = { country_event = wtt_xian_incident.3 }
+	}
+
+}
+
+#Xian incident - Chiang agrees
+country_event = {
+	id = wtt_xian_incident.2
+	title = wtt_xian_incident.2.t
+	desc = wtt_xian_incident.2.desc
+	picture = GFX_report_event_chinese_japanese_handshake
+
+	is_triggered_only = yes
+	
+	option = {
+		name = wtt_xian_incident.2.a #ask him to ally with the communists
+		CHI = { country_event = wtt_xian_incident.4 }
+	}
+
+}
+
+#Xian incident - Chiang refuses
+country_event = {
+	id = wtt_xian_incident.3
+	title = wtt_xian_incident.3.t
+	desc = wtt_xian_incident.3.desc
+	picture = GFX_report_event_china_chiang_kai_shek
+
+	is_triggered_only = yes
+	
+	option = {
+		name = wtt_xian_incident.3.a
+		set_global_flag = CHI_xian_refused
+		if = {
+			limit = {
+				is_in_faction_with = FROM
+			}
+			FROM = { remove_from_faction = event_target:CHI_xian_instigator }
+		}
+		if = {
+			limit = {
+				is_subject_of = FROM
+			}
+			OVERLORD = { 
+				set_autonomy = { 
+					target = event_target:CHI_xian_instigator
+					autonomy_state = autonomy_free 
+				}
+				create_wargoal = {
+					type = puppet_wargoal_focus
+					target = event_target:CHI_xian_instigator
+				}
+			}
+		}
+		clr_country_flag = CHI_xian_instigator_flag
+	}
+}
+
+#Xian incident - Chiang asked to ally with commies
+country_event = {
+	id = wtt_xian_incident.4
+	title = wtt_xian_incident.4.t
+	desc = wtt_xian_incident.4.desc
+	picture = GFX_report_event_china_politicians_captured
+
+	is_triggered_only = yes
+	
+	option = {
+		name = wtt_xian_incident.4.a #agree
+		ai_chance = {
+			base = 25
+			modifier = {
+				factor = 4
+				has_war_with = JAP
+			}
+			modifier = {
+				PRC = {
+					has_completed_focus = PRC_social_democracy
+				}
+				factor = 2 #Commies being nice to us
+			}
+			modifier = {
+				CHI_is_on_historical_plan_trigger = yes
+				factor = 0
+			}
+			modifier = {
+				is_historical_focus_on = yes
+				factor = 0
+			}
+		}
+		PRC = { country_event = wtt_xian_incident.5 }
+	}
+
+	option = {
+		name = wtt_xian_incident.4.b #disgree
+		ai_chance = {
+			base = 75
+			modifier = {
+				PRC = {
+					has_completed_focus = PRC_focus_on_china #commies being mean to us!
+				}
+				factor = 2
+			}
+			modifier = {
+				JAP = {
+					NOT = {
+						has_government = fascism #Japan doesn't seem interested in China
+					}
+				}
+				factor = 2
+			}
+		}
+		event_target:CHI_xian_instigator = { country_event = wtt_xian_incident.6 }
+	}
+
+}
+
+#Xian incident - Chiang agrees to ally with commies, event for PRC
+country_event = {
+	id = wtt_xian_incident.5
+	title = wtt_xian_incident.5.t
+	desc = wtt_xian_incident.5.desc
+	picture = GFX_report_event_generic_read_write
+
+	is_triggered_only = yes
+	
+	option = {
+		name = wtt_xian_incident.5.a #accept the proposal
+		ai_chance = {
+			base = 80
+		}
+		hidden_effect = {
+			news_event = { id = news.288 days = 1 }
+		}
+		if = {
+			limit = {
+				NOT = { is_in_faction_with = CHI }
+				CHI = { is_in_faction = no }
+			}
+			CHI = {
+				set_rule = { can_create_factions = yes }
+				create_faction = chinese_united_front
+			}
+		}
+		if = {
+			limit = {
+				CHI = { is_faction_leader = yes }
+			}
+			CHI = { add_to_faction = PRC }
+			PRC = { 
+				add_ai_strategy = {
+					type = alliance
+					id = "CHI"
+					value = 200
+				}
+			}
+			every_country = {
+				limit = {
+					is_subject_of = CHI
+				}
+				CHI = { add_to_faction = PREV }
+			}
+		}
+		event_target:CHI_xian_instigator = { clr_country_flag = CHI_xian_instigator_flag }
+	}
+
+	option = {
+		name = wtt_xian_incident.5.b #no deal
+		ai_chance = {
+			base = 20
+			modifier = {
+				has_country_flag = SOV_xian_refuse
+				factor = 0
+			}
+		}
+		hidden_effect = {
+			news_event = { id = wtt_news.33 days = 1 }
+		}
+	}
+
+}
+
+#Xian incident - Chiang refuses to ally with commies
+country_event = {
+	id = wtt_xian_incident.6
+	title = wtt_xian_incident.6.t
+	desc = wtt_xian_incident.6.desc
+	picture = GFX_report_event_china_chiang_kai_shek
+
+	is_triggered_only = yes
+	
+	option = {
+		name = wtt_xian_incident.6.a #arrest him
+		ai_chance = {
+			base = 70
+		}		
+		CHI = { country_event = wtt_xian_incident.8 }
+	}
+
+	option = {
+		name = wtt_xian_incident.6.b #nothing to be done
+		ai_chance = {
+			base = 30
+			modifier = {
+				CHI_is_on_historical_plan_trigger = yes
+				factor = 0
+			}
+			modifier = {
+				is_historical_focus_on = yes
+				factor = 0
+			}
+		}
+		event_target:CHI_xian_instigator = { clr_country_flag = CHI_xian_instigator_flag }
+		#TODO_WTT_CD: News event: Chiang refuses proposal to ally with commies
+	}
+
+}
+
+#Xian incident - Chiang arrested, execute?
+country_event = {
+	id = wtt_xian_incident.7
+	title = wtt_xian_incident.7.t
+	desc = { text = wtt_xian_incident.7.desc_a trigger = { NOT = { has_country_flag = SOV_xian_refuse } } }
+	desc = { text = wtt_xian_incident.7.desc_b trigger = { has_country_flag = SOV_xian_refuse } }
+	picture = GFX_report_event_china_politicians_captured
+
+	is_triggered_only = yes
+	
+	option = {
+		trigger = {
+			NOT = {
+				has_war_with = SOV
+			}
+			NOT = {
+				has_country_flag = SOV_xian_refuse
+			}
+		}
+		name = wtt_xian_incident.7.a #ask Soviets
+		ai_chance = {
+			base = 70
+		}
+
+		SOV = { country_event = { id = wtt_xian_incident.9 days = 1 } }
+	}
+
+	option = {
+		name = wtt_xian_incident.7.b #just do it
+		ai_chance = {
+			base = 30
+			modifier = {
+				CHI_is_on_historical_plan_trigger = yes
+				factor = 0
+			}
+			modifier = {
+				is_historical_focus_on = yes
+				factor = 0
+			}
+		}
+		CHI = {
+			kill_country_leader = yes
+			if = {
+				limit = {
+					NOT = {
+						has_global_flag = CHI_wang_defects
+					}
+				}
+				create_country_leader = {
+					name = "Wang Jingwei"
+					desc = "POLITICS_WANG_JINGWEI_DESC"
+					picture = "GFX_portrait_chi_wang_jingwei"
+					expire = "1965.1.1"
+					ideology = despotism
+					traits = {
+						#
+					}
+				}
+			}
+			create_wargoal = {
+				target = PREV
+				type = annex_everything
+			}
+		}
+		hidden_effect = {
+			news_event = { id = wtt_news.30 days = 1 }
+		}
+		event_target:CHI_xian_instigator = { clr_country_flag = CHI_xian_instigator_flag }
+	}
+	option = {
+		name = wtt_xian_incident.7.c #don't do it, offer to ally instead
+		ai_chance = {
+			base = 30
+		}
+		CHI = {
+			country_event = wtt_xian_incident.10
+		}
+		
+	}
+	option = {
+		name = wtt_xian_incident.7.d #no deals with anyone
+		ai_chance = {
+			base = 0
+		}
+		hidden_effect = {
+			news_event = { id = wtt_news.33 days = 1 random_hours = 36 }
+		}
+		
+	}
+
+}
+#Xian incident - Chiang arrested, intervene?
+country_event = {
+	id = wtt_xian_incident.8
+	title = wtt_xian_incident.8.t
+	desc = wtt_xian_incident.8.desc
+	picture = GFX_report_event_chinese_officers
+
+	is_triggered_only = yes
+	
+	option = {
+		name = wtt_xian_incident.8.a #military option
+		ai_chance = {
+			base = 30
+			modifier = {
+				has_war = no
+				factor = 1.5
+			}
+			modifier = {
+				CHI_is_on_historical_plan_trigger = yes
+				factor = 0
+			}
+			modifier = {
+				is_historical_focus_on = yes
+				factor = 0
+			}
+		}
+		declare_war_on = { 
+			type = annex_everything
+			target = event_target:CHI_xian_instigator
+		}
+		event_target:CHI_xian_instigator = { clr_country_flag = CHI_xian_instigator_flag }
+	}
+
+	option = {
+		name = wtt_xian_incident.8.b #don't do anything
+		ai_chance = {
+			base = 70
+		}
+		PRC = { country_event = wtt_xian_incident.7 }
+	}
+}
+
+#Xian incident - Chiang arrested, commies want to execute, allow? (SOV)
+country_event = {
+	id = wtt_xian_incident.9
+	title = wtt_xian_incident.9.t
+	desc = wtt_xian_incident.9.desc
+	picture = GFX_report_event_stalin_meeting
+
+	is_triggered_only = yes
+	
+	option = {
+		ai_chance = {
+			base = 50
+			modifier = {
+				CHI_is_on_historical_plan_trigger = yes
+				factor = 0
+			}
+			modifier = {
+				is_historical_focus_on = yes
+				factor = 0
+			}
+		}
+		name = wtt_xian_incident.9.a #approve
+		CHI = {
+			kill_country_leader = yes
+			if = {
+				limit = {
+					NOT = {
+						has_global_flag = CHI_wang_defects
+					}
+				}
+				create_country_leader = {
+					name = "Wang Jingwei"
+					desc = "POLITICS_WANG_JINGWEI_DESC"
+					picture = "GFX_portrait_chi_wang_jingwei"
+					expire = "1965.1.1"
+					ideology = despotism
+					traits = {
+						#
+					}
+				}
+			}
+			create_wargoal = {
+				target = PRC
+				type = annex_everything
+			}
+		}
+		event_target:CHI_xian_instigator = { clr_country_flag = CHI_xian_instigator_flag }
+		hidden_effect = {
+			news_event = { id = wtt_news.31 days = 1 }
+		}
+	}
+
+	option = {
+		name = wtt_xian_incident.9.b #disapprove
+		ai_chance = {
+			base = 50
+			modifier = {
+				has_war_with = JAP
+				factor = 3
+			}
+		}
+		FROM = {
+			set_country_flag = SOV_xian_refuse
+			country_event = wtt_xian_incident.7
+		}
+	}
+}
+
+#Xian incident - PRC opts for the United Front, event for CHI
+country_event = {
+	id = wtt_xian_incident.10
+	title = wtt_xian_incident.10.t
+	desc = wtt_xian_incident.10.desc
+	picture = GFX_report_event_china_chiang_mao
+
+	is_triggered_only = yes
+	
+	option = {
+		
+		name = wtt_xian_incident.10.a #approve
+		ai_chance = {
+			base = 50
+		}
+		hidden_effect = {
+			news_event = { id = news.288 days = 1 } # United Front forms
+		}
+		if = {
+			limit = {
+				NOT = { is_in_faction_with = CHI }
+				CHI = { is_in_faction = no }
+			}
+			CHI = {
+				set_rule = { can_create_factions = yes }
+				create_faction = chinese_united_front
+			}
+		}
+		if = {
+			limit = {
+				CHI = { is_faction_leader = yes }
+			}
+			CHI = { add_to_faction = PRC }
+			PRC = { 
+				add_ai_strategy = {
+					type = alliance
+					id = "CHI"
+					value = 200
+				}
+			}
+			every_country = {
+				limit = {
+					is_subject_of = CHI
+				}
+				CHI = { add_to_faction = PREV }
+			}
+		}
+		event_target:CHI_xian_instigator = { clr_country_flag = CHI_xian_instigator_flag }
+	}
+
+	option = {
+		name = wtt_xian_incident.10.b #disapprove
+		ai_chance = {
+			base = 10
+			modifier = {
+				CHI_is_on_historical_plan_trigger = yes
+				factor = 0
+			}
+			modifier = {
+				is_historical_focus_on = yes
+				factor = 0
+			}
+		}
+		reverse_add_opinion_modifier = { target = FROM modifier = CHI_xian_refused }
+		hidden_effect = {
+			news_event = { id = wtt_news.32 days = 1 }
+		}
+		event_target:CHI_xian_instigator = { clr_country_flag = CHI_xian_instigator_flag }
+	}
+}
+
+add_namespace = wtt_china_shared
+
+# China anti-imperialism notification event
+country_event = {
+	id = wtt_china_shared.1
+	title = wtt_china_shared.1.t
+	desc = wtt_china_shared.1.desc
+	picture = GFX_report_event_chinese_soldiers_02
+
+	is_triggered_only = yes
+	
+	option = { #accept
+		name = wtt_china_shared.1.a
+		ai_chance = {
+			base = 70
+		}
+		add_ideas = CHI_chinese_support
+		FROM = {
+			country_event = wtt_china_shared.2
+		}
+		OVERLORD = { #TODO_WTT_CD TEST THIS: Maybe problematic case with Mongolia, noted in the tooltip when I tested the event, but where no event is triggered. To be tested for confirmation
+			country_event = wtt_china_shared.4
+		}
+	}
+	option = { #refuse
+		name = wtt_china_shared.1.b
+		ai_chance = {
+			base = 30
+		}
+		reverse_add_opinion_modifier = {
+			target = FROM
+			modifier = CHI_refused_support
+		}
+		FROM = {
+			country_event = wtt_china_shared.3
+		}
+	}
+}
+#country accepts support
+country_event = {
+	id = wtt_china_shared.2
+	title = wtt_china_shared.2.t
+	desc = wtt_china_shared.2.desc
+	picture = GFX_report_event_chinese_japanese_handshake
+
+	is_triggered_only = yes
+	
+	option = { #accept
+		name = wtt_china_shared.2.a
+	}
+}
+#country refuses support
+country_event = {
+	id = wtt_china_shared.3
+	title = wtt_china_shared.3.t
+	desc = wtt_china_shared.3.desc
+	picture = GFX_report_event_generic_read_write
+
+	is_triggered_only = yes
+	
+	option = { #accept
+		name = wtt_china_shared.3.a
+	}
+}
+#country has accepted support, event for overlord
+country_event = {
+	id = wtt_china_shared.4
+	title = wtt_china_shared.4.t
+	desc = wtt_china_shared.4.desc
+	picture = GFX_report_event_journalists_speech
+
+	is_triggered_only = yes
+	
+	option = { #accept
+		name = wtt_china_shared.4.a
+	}
+}
+
+#ask for American volunteers - event for USA
+country_event = {
+	id = wtt_china_shared.10
+	title = wtt_china_shared.10.t
+	desc = { text = wtt_china_shared.10.desc_a trigger = { FROM = { has_idea = CHI_soong_mei_ling } } }
+	desc = { text = wtt_china_shared.10.desc_b trigger = { NOT = { FROM = { has_idea = CHI_soong_mei_ling } } } }
+	picture = GFX_report_event_china_flying_tigers
+
+	is_triggered_only = yes
+	
+	option = { #accept
+		name = wtt_china_shared.10.a
+		ai_chance = {
+			base = 70
+			modifier = {
+				JAP = {
+					NOT = {
+						has_government = fascism
+					}
+				}
+				factor = 0.5
+			}
+			modifier = {
+				has_war_support < 0.5
+				factor = 2
+			}
+			modifier = {
+				FROM = {
+					has_idea = CHI_soong_mei_ling
+				}
+				factor = 2 #this nice lady wants to buy some fighter planes, who are we to tell her no? So what if she has no money?
+			}
+		}
+		set_country_flag = CHI_flying_tigers
+		add_war_support = 0.05
+		add_ai_strategy = {
+			type = send_volunteers_desire
+			id = ROOT
+			value = 200
+		}
+		add_ai_strategy = {
+			type = support
+			id = ROOT
+			value = 200
+		}
+		hidden_effect = {
+			news_event = { id = wtt_news.34 days = 1 }
+		}
+		unlock_decision_tooltip = CHI_flying_tigers
+	}
+
+	option = { #refuse
+		name = wtt_china_shared.10.b
+		ai_chance = {
+			base = 30
+		}
+		reverse_add_opinion_modifier = { target = FROM modifier = CHI_refused_support }
+		add_war_support = -0.1
+		JAP = {
+			add_opinion_modifier = { target = USA modifier = large_increase }
+		}
+	}
+}
+
+#ask for Soviet volunteers - event for SOV
+country_event = {
+	id = wtt_china_shared.11
+	title = wtt_china_shared.11.t
+	desc = { text = wtt_china_shared.11.desc_a trigger = { FROM = { has_government = communism } } }
+	desc = { text = wtt_china_shared.11.desc_b trigger = { NOT = { FROM = { has_government = communism } } } }
+	picture = GFX_report_event_china_soviet_volunteers
+
+	is_triggered_only = yes
+	
+	option = { #accept
+		name = wtt_china_shared.11.a
+		ai_chance = {
+			base = 70
+		}
+		set_country_flag = CHI_soviet_volunteer_group
+		air_experience = 25
+		add_ai_strategy = {
+			type = send_volunteers_desire
+			id = ROOT
+			value = 200
+		}
+		add_ai_strategy = {
+			type = support
+			id = ROOT
+			value = 200
+		}
+		unlock_decision_tooltip = CHI_soviet_volunteer_group
+	}
+
+	option = { #refuse
+		name = wtt_china_shared.11.b
+		ai_chance = {
+			base = 30
+			modifier = {
+				SOV_is_on_historical_plan_trigger = yes
+				factor = 0
+			}
+			modifier = {
+				is_historical_focus_on = yes
+				factor = 0
+			}
+		}
+		reverse_add_opinion_modifier = { target = FROM modifier = CHI_refused_support }
+		add_war_support = -0.1
+		JAP = {
+			add_opinion_modifier = { target = SOV modifier = large_increase }
+		}
+	}
+}
+#FROM invites Stillwell - event for USA
+country_event = {
+	id = wtt_china_shared.12
+	title = wtt_china_shared.12.t
+	desc = wtt_china_shared.12.desc
+	picture = GFX_report_event_chinese_officers
+
+	is_triggered_only = yes
+	
+	option = { #accept - Stillwell
+		name = wtt_china_shared.12.a
+		ai_chance = {
+			base = 30
+		}
+		set_country_flag = joseph_stilwell_sent_to_china
+		random_army_leader = { 
+			limit = { has_id = 601 }
+			set_nationality = FROM
+			save_event_target_as = CHI_USA_general
+		}
+		FROM = {
+			country_event = wtt_china_shared.13
+		}
+	}
+
+	option = { #accept - MacArthur
+		name = wtt_china_shared.12.c
+		ai_chance = {
+			base = 30
+			modifier = {
+				USA_is_on_historical_plan_trigger = yes
+				factor = 0
+			}
+			modifier = {
+				is_historical_focus_on = yes
+				factor = 0
+			}
+		}
+		set_country_flag = joseph_stilwell_sent_to_china
+		random_army_leader = { 
+			limit = { has_id = 57 }
+			set_nationality = FROM
+			save_event_target_as = CHI_USA_general
+		}
+		FROM = {
+			country_event = wtt_china_shared.13
+		}
+	}
+
+	option = { #accept - Eisenhower
+		name = wtt_china_shared.12.d
+		ai_chance = {
+			base = 30
+			modifier = {
+				USA_is_on_historical_plan_trigger = yes
+				factor = 0
+			}
+			modifier = {
+				is_historical_focus_on = yes
+				factor = 0
+			}
+		}
+		set_country_flag = joseph_stilwell_sent_to_china
+		random_army_leader = { 
+			limit = { has_id = 602 }
+			set_nationality = FROM
+			save_event_target_as = CHI_USA_general
+		}
+		FROM = {
+			country_event = wtt_china_shared.13
+		}
+	}
+
+	option = { #refuse
+		name = wtt_china_shared.12.b
+		ai_chance = {
+			base = 10
+			modifier = {
+				USA_is_on_historical_plan_trigger = yes
+				factor = 0
+			}
+			modifier = {
+				is_historical_focus_on = yes
+				factor = 0
+			}
+		}
+		reverse_add_opinion_modifier = { target = FROM modifier = CHI_refused_support }
+		add_war_support = -0.1
+		FROM = {
+			country_event = wtt_china_shared.14
+		}
+	}
+}
+
+#FROM invites Stillwell - positive response
+country_event = {
+	id = wtt_china_shared.13
+	title = wtt_china_shared.13.t
+	desc = wtt_china_shared.13.desc
+	picture = GFX_report_event_generic_usa_treaty
+
+	is_triggered_only = yes
+	
+	option = { #accept
+		name = wtt_china_shared.13.a
+		effect_tooltip = {
+			USA = {
+				event_target:CHI_USA_general = { 
+					set_nationality = FROM.FROM
+				}
+			}
+		}
+	}
+}
+
+#FROM invites Stillwell - negative response
+country_event = {
+	id = wtt_china_shared.14
+	title = wtt_china_shared.14.t
+	desc = wtt_china_shared.14.desc
+	picture = GFX_report_event_generic_read_write
+
+	is_triggered_only = yes
+	
+	option = { #accept
+		name = wtt_china_shared.14.a
+	}
+}
+
+###  #  # ###  #   #  ##      ###   ##   ##  ###  
+#  # #  # #  # ## ## #  #     #  # #  # #  # #  # 
+###  #  # ###  # # # ####     ###  #  # #### #  # 
+#  # #  # #  # #   # #  #     #  # #  # #  # #  # 
+###   ##  #  # #   # #  #     #  #  ##  #  # ###  
+
+add_namespace = wtt_burma_road
+#Info event that Burma road has been closed due to occupation of state
+country_event = {
+	id = wtt_burma_road.1
+	title = wtt_burma_road.1.t
+	desc = wtt_burma_road.1.desc
+	picture = GFX_report_event_burma_road
+	is_triggered_only = yes
+	
+
+	option = {
+		name = wtt_burma_road.1.a
+	}
+
+}
+
+#Info event that Burma road has been closed from decision.
+country_event = {
+	id = wtt_burma_road.2
+	title = wtt_burma_road.1.t
+	
+	desc = {
+		text = wtt_burma_road.2.desc
+		trigger = {
+			NOT = { FROM = { has_war_with = ROOT } }
+		}
+	}
+
+	desc = {
+		text = wtt_burma_road.2.desc_war_with_from
+		trigger = {
+			FROM = { has_war_with = ROOT }
+		}
+	}
+	picture = GFX_report_event_generic_sign_treaty2
+
+	is_triggered_only = yes
+	
+
+	option = {
+		name = wtt_burma_road.1.a
+	}
+
+}
+
+#Info event that part of the route has been reopened from decision.
+country_event = {
+	id = wtt_burma_road.3
+	title = wtt_burma_road.3.t
+	desc = wtt_burma_road.3.desc
+	picture = GFX_report_event_ledo_road
+
+	is_triggered_only = yes
+	
+
+	option = {
+		name = wtt_burma_road.3.a
+	}
+
+}
+
+#Info event that route is fully reopened from decision.
+country_event = {
+	id = wtt_burma_road.4
+	title = wtt_burma_road.4.t
+	desc = wtt_burma_road.4.desc
+	picture = GFX_report_event_burma_road
+
+	is_triggered_only = yes	
+
+	option = {
+		name = wtt_burma_road.4.a
+		add_offsite_building = { type = arms_factory level = CHI_burma_road_closed_level }			
+		set_variable = { CHI_burma_road = CHI_burma_road_closed_level }
+		clear_variable = CHI_burma_road_closed_level
+	}
+
+}
+
+#   ### ###   ##      ###   ##   ##  ###  
+#   #   #  # #  #     #  # #  # #  # #  # 
+#   ##  #  # #  #     ###  #  # #### #  # 
+#   #   #  # #  #     #  # #  # #  # #  # 
+### ### ###   ##      #  #  ##  #  # ###  
+
+add_namespace = wtt_ledo_road
+#Info event that Ledo road has been closed due to occupation of state
+country_event = {
+	id = wtt_ledo_road.1
+	title = wtt_ledo_road.1.t
+	desc = wtt_ledo_road.1.desc
+	picture = GFX_report_event_nationalist_china_machinegun_firing
+
+	is_triggered_only = yes
+	
+
+	option = {
+		name = wtt_burma_road.1.a
+	}
+
+}
+
+#Info event that Ledo road has been closed from decision.
+country_event = {
+	id = wtt_ledo_road.2
+	title = wtt_ledo_road.1.t
+	
+	desc = {
+		text = wtt_ledo_road.2.desc
+		trigger = {
+			NOT = { FROM = { has_war_with = ROOT } }
+		}
+	}
+
+	desc = {
+		text = wtt_ledo_road.2.desc_war_with_from
+		trigger = {
+			FROM = { has_war_with = ROOT }
+		}
+	}
+	picture = GFX_report_event_indian_soldiers #TODO_WTT_CD event pic
+
+	is_triggered_only = yes
+	
+
+	option = {
+		name = wtt_burma_road.1.a
+	}
+
+}
+
+#Info event that part of the route has been reopened from decision.
+country_event = {
+	id = wtt_ledo_road.3
+	title = wtt_ledo_road.3.t
+	desc = wtt_ledo_road.3.desc
+	picture = GFX_report_event_ledo_road
+
+	is_triggered_only = yes
+	
+
+	option = {
+		name = wtt_ledo_road.3.a
+	}
+
+}
+
+#Info event that route is fully reopened from decision.
+country_event = {
+	id = wtt_ledo_road.4
+	title = wtt_ledo_road.4.t
+	desc = wtt_ledo_road.4.desc
+	picture = GFX_report_event_ledo_road
+
+	is_triggered_only = yes	
+
+	option = {
+		name = wtt_ledo_road.4.a
+		add_offsite_building = { type = arms_factory level = CHI_ledo_road_closed_level }			
+		set_variable = { CHI_ledo_road = CHI_ledo_road_closed_level }
+		clear_variable = CHI_ledo_road_closed_level
+	}
+
+}
+
+#  #  ##  #  #  ##  ###     ###   ##  #  # ### ### 
+#  # #  # ## # #  #  #      #  # #  # #  #  #  #   
+#### #### # ## #  #  #      ###  #  # #  #  #  ##  
+#  # #  # #  # #  #  #      #  # #  # #  #  #  #   
+#  # #  # #  #  ##  ###     #  #  ##   ##   #  ### 
+
+add_namespace = wtt_hanoi_route
+#Info event that Hanoi route road has been closed due to occupation of state
+country_event = {
+	id = wtt_hanoi_route.1
+	title = wtt_hanoi_route.1.t
+	desc = wtt_hanoi_route.1.desc
+	picture = GFX_report_event_merchant_ship_01
+
+	is_triggered_only = yes
+	
+
+	option = {
+		name = wtt_burma_road.1.a
+	}
+
+}
+
+#Info event that Hanoi route has been closed from decision.
+country_event = {
+	id = wtt_hanoi_route.2
+	title = wtt_hanoi_route.1.t
+	
+	desc = {
+		text = wtt_hanoi_route.2.desc
+		trigger = {
+			NOT = { FROM = { has_war_with = ROOT } }
+		}
+	}
+
+	desc = {
+		text = wtt_hanoi_route.2.desc_war_with_from
+		trigger = {
+			FROM = { has_war_with = ROOT }
+		}
+	}
+	picture = GFX_report_event_merchant_ship_01
+
+	is_triggered_only = yes
+	
+
+	option = {
+		name = wtt_burma_road.1.a
+	}
+
+}
+
+
+### #  # ###     #  # #  # #   # ###  
+ #  #  # #       #  # #  # ## ## #  # 
+ #  #### ##      #### #  # # # # ###  
+ #  #  # #       #  # #  # #   # #    
+ #  #  # ###     #  #  ##  #   # #    
+add_namespace = wtt_the_hump
+#Info event that hump route road has been closed due to occupation of state
+country_event = {
+	id = wtt_the_hump.1
+	title = wtt_the_hump.1.t
+	desc = wtt_the_hump.1.desc
+	picture = GFX_report_event_nationalist_china_machinegun_firing
+
+	is_triggered_only = yes
+	
+
+	option = {
+		name = wtt_burma_road.1.a
+	}
+
+}
+
+#Info event that The Hump has been closed from decision.
+country_event = {
+	id = wtt_the_hump.2
+	title = wtt_the_hump.1.t
+	
+	desc = {
+		text = wtt_the_hump.2.desc
+		trigger = {
+			NOT = { FROM = { has_war_with = ROOT } }
+		}
+	}
+
+	desc = {
+		text = wtt_the_hump.2.desc_war_with_from
+		trigger = {
+			FROM = { has_war_with = ROOT }
+		}
+	}
+	picture = GFX_report_event_generic_read_write
+
+	is_triggered_only = yes
+	
+
+	option = {
+		name = wtt_burma_road.1.a
+	}
+
+}
+
+#Info event that part of the route has been reopened from decision.
+country_event = {
+	id = wtt_the_hump.3
+	title = wtt_the_hump.3.t
+	desc = wtt_the_hump.3.desc
+	picture = GFX_report_event_generic_bombers
+
+	is_triggered_only = yes
+	
+
+	option = {
+		name = wtt_the_hump.3.a
+	}
+
+}
+
+#Info event that route is fully reopened from decision.
+country_event = {
+	id = wtt_the_hump.4
+	title = wtt_the_hump.4.t
+	desc = wtt_the_hump.4.desc
+	picture = GFX_report_event_generic_bombers
+
+	is_triggered_only = yes	
+
+	option = {
+		name = wtt_the_hump.4.a
+	}
+
+}
+
+
+ ##  ###  ###  ###   ##   ##   ##  #  #      ###  ##  ###   ##  #  # 
+#  # #  # #  # #  # #  # #  # #  # #  #        # #  # #  # #  # ## # 
+#### ###  ###  ###  #  # #### #    ####        # #### ###  #### # ## 
+#  # #    #    #  # #  # #  # #  # #  #     #  # #  # #    #  # #  # 
+#  # #    #    #  #  ##  #  #  ##  #  #      ##  #  # #    #  # #  # 
+
+add_namespace = wtt_warlord
+
+#Warlord approaches Japan asking to become a subject
+country_event = {
+	id = wtt_warlord.1
+	title = wtt_warlord.1.t
+	desc = wtt_warlord.1.desc
+	picture = GFX_report_event_chinese_japanese_handshake
+
+	is_triggered_only = yes
+	
+	#Accept puppet
+	option = {
+		name = wtt_warlord.1.a
+		ai_chance = { 
+			base = 10
+		}
+		FROM = { country_event = { id = wtt_warlord.2 } }
+		puppet = FROM
+	}
+
+	#Never
+	option = {
+		name = wtt_warlord.1.b
+		ai_chance = { 
+			base = 0
+		}
+		FROM = { country_event = { id = wtt_warlord.3 } }
+	}
+}
+
+# Answer from Japan to warloard wtt_warlord.1 - Yes
+country_event = {
+	id = wtt_warlord.2
+	title = wtt_warlord.2.t
+	desc = wtt_warlord.2.desc
+	picture = GFX_report_event_asian_politicians
+
+	is_triggered_only = yes
+	
+	option = {
+		name = wtt_warlord.2.a
+	}
+}
+
+
+# Answer from warlord wtt_warlord.1 - No
+country_event = {
+	id = wtt_warlord.3
+	title = wtt_warlord.3.t
+	desc = wtt_warlord.3.desc
+	picture = GFX_report_event_japanese_soldiers_01
+
+	is_triggered_only = yes
+	
+	option = {
+		name = wtt_warlord.3.a
+	}
+}
+
+#Move capital if someone wins civil war
+country_event = {
+	id = wtt_china.204
+	title = china.204.t
+	desc = china.204.d
+	picture = GFX_report_event_chinese_soldiers
+
+	is_triggered_only = yes
+
+	#Move to Beijing
+	option = {
+		name = china.204.a
+		ai_chance = {
+			base = 90
+		}
+		trigger = {
+			owns_state = 608
+		}
+		set_capital = 608
+	}
+
+	#Move to Nanjing
+	option = {
+		name = china.204.b
+		ai_chance = {
+			base = 10
+		}
+		trigger = {
+			owns_state = 613
+		}
+		custom_effect_tooltip = CHI_nanjing_tt
+		hidden_effect = {
+			set_capital = 613
+		}
+	}
+
+	#Stay where you are
+	option = {
+		name = china.204.c
+		ai_chance = {
+			base = 0			
+		}
+	}
+}


### PR DESCRIPTION
In the WtT_China events, I added for every:
			modifier = {
				CHI_is_on_historical_plan_trigger = yes
				factor = 0
			}

this modifier aswell:
			modifier = {
				is_historical_focus_on = yes
				factor = 0
			}

So if we use my ai_script for China, which is still somewhat historical, the AI still chose the historical event options for forming the Chinese United Front (and other events, like Soviet Volunteers and American Flying Tigers), when Historical Foci are picked on gamestart.