### PR TITLE
Voigt DoD hungary event fix

### DIFF
--- a/events/DOD_Hungary.txt
+++ b/events/DOD_Hungary.txt
@@ -1449,7 +1449,6 @@ country_event = {
 
 	option = {# Prepare for war!
 		name = DOD_hungary.53.b
-		HUN = { country_event = { id = DOD_hungary.54 hours = 24 } }
 		ai_chance = {
 			factor = 35
 			modifier = {
@@ -1513,6 +1512,47 @@ country_event = {
 				}
 			}
 			ENG = { country_event = { id = DOD_hungary.60 } } #Britain given option to intervene, if they don't have bigger problems
+		}
+		if = {
+			limit = { 
+				AND = {
+					NOT = {
+						GER = {
+							NOT = {
+								OR = {
+									has_war_with = HUN
+									has_war_with = ROM
+								}
+							}
+						}
+					}
+					NOT = {
+						ITA = {
+							NOT = {
+								OR = {
+									has_war_with = HUN
+									has_war_with = ROM
+								}
+								is_in_faction_with = GER
+							}
+						}
+					}
+					NOT = {
+						FRA = {
+							has_war = no
+							has_government = democratic
+						}
+					}
+					NOT = {
+						ENG = {
+							has_war = no
+							has_government = democratic
+							has_completed_focus = uk_balkan_strategy
+						}
+					}
+				}
+			}
+			HUN = { country_event = { id = DOD_hungary.54 hours = 24 } }
 		}
 	}
 
@@ -1901,9 +1941,8 @@ country_event = {
 
 	option = {# well done us
 		name = DOD_hungary.57.a
-		add_stability = 0.05
-		remove_ideas = ROM_war_preparation
-	
+		ROM = { add_stability = 0.05 }
+		ROM = { remove_ideas = ROM_war_preparation }
 	}
 }
 #Hungary seeks Mediation
@@ -2068,6 +2107,7 @@ country_event = {
 		ai_chance = {
 			factor = 35
 		}
+		HUN = { country_event = { id = DOD_hungary.54 hours = 24 } }
 		
 	}
 }
@@ -2172,8 +2212,8 @@ country_event = {
 				NOT = { has_global_flag = Balkan_crisis_HUN_folded }
 				NOT = { has_global_flag = Balkan_crisis_mediation_requested }
 			}
+		HUN = { remove_ideas = HUN_war_preparation }
 		ROM = {country_event = { id = DOD_hungary.57 } }
-		remove_ideas = HUN_war_preparation
 		}
 	}
 

--- a/events/DOD_Hungary.txt
+++ b/events/DOD_Hungary.txt
@@ -2150,7 +2150,7 @@ country_event = {
 		ai_chance = {
 			factor = 35
 		}
-		HUN = { country_event = { id = DOD_hungary.54 hours = 24 } }
+		HUN = { country_event = { id = DOD_hungary.54 hours = 72 } }
 	}
 }
 

--- a/events/DOD_Hungary.txt
+++ b/events/DOD_Hungary.txt
@@ -1577,6 +1577,18 @@ country_event = {
 
 	option = {# Back down
 		name = DOD_hungary.54.a
+		trigger = {
+			ROM = {
+				has_idea = {
+					ROM_war_preparation
+				}
+			}
+			HUN = {
+				has_idea = {
+					HUN_war_preparation
+				}
+			}
+		}
 		ai_chance = {
 			factor = 35
 			modifier = {
@@ -1600,6 +1612,18 @@ country_event = {
 
 	option = {# To war!
 		name = DOD_hungary.54.b
+		trigger = {
+			ROM = {
+				has_idea = {
+					ROM_war_preparation
+				}
+			}
+			HUN = {
+				has_idea = {
+					HUN_war_preparation
+				}
+			}
+		}
 		ai_chance = {
 			factor = 35
 			modifier = { 
@@ -1621,10 +1645,45 @@ country_event = {
 	
 	option = {# Ask for mediation
 		name = DOD_hungary.54.c
+		trigger = {
+			ROM = {
+				has_idea = {
+					ROM_war_preparation
+				}
+			}
+			HUN = {
+				has_idea = {
+					HUN_war_preparation
+				}
+			}
+		}
 		ai_chance = {
 			factor = 35
 		}
 		country_event = { id = DOD_hungary.55 }
+	}
+
+	option = {# Already resolved
+		name = DOD_hungary.54.d
+		trigger = {
+			ROM = {
+				NOT = {
+					has_idea = {
+						ROM_war_preparation
+					}
+				}
+			}
+			HUN = {
+				NOT = {
+					has_idea = {
+						HUN_war_preparation
+					}
+				}
+			}
+		}
+		ai_chance = {
+			factor = 35
+		}
 	}
 }
 
@@ -2108,7 +2167,6 @@ country_event = {
 			factor = 35
 		}
 		HUN = { country_event = { id = DOD_hungary.54 hours = 24 } }
-		
 	}
 }
 

--- a/events/DOD_Hungary.txt
+++ b/events/DOD_Hungary.txt
@@ -1579,14 +1579,10 @@ country_event = {
 		name = DOD_hungary.54.a
 		trigger = {
 			ROM = {
-				has_idea = {
-					ROM_war_preparation
-				}
+				has_idea = 	ROM_war_preparation
 			}
 			HUN = {
-				has_idea = {
-					HUN_war_preparation
-				}
+				has_idea = HUN_war_preparation
 			}
 		}
 		ai_chance = {
@@ -1614,14 +1610,10 @@ country_event = {
 		name = DOD_hungary.54.b
 		trigger = {
 			ROM = {
-				has_idea = {
-					ROM_war_preparation
-				}
+				has_idea = 	ROM_war_preparation
 			}
 			HUN = {
-				has_idea = {
-					HUN_war_preparation
-				}
+				has_idea = HUN_war_preparation
 			}
 		}
 		ai_chance = {
@@ -1647,14 +1639,10 @@ country_event = {
 		name = DOD_hungary.54.c
 		trigger = {
 			ROM = {
-				has_idea = {
-					ROM_war_preparation
-				}
+				has_idea = 	ROM_war_preparation
 			}
 			HUN = {
-				has_idea = {
-					HUN_war_preparation
-				}
+				has_idea = HUN_war_preparation
 			}
 		}
 		ai_chance = {
@@ -1668,16 +1656,12 @@ country_event = {
 		trigger = {
 			ROM = {
 				NOT = {
-					has_idea = {
-						ROM_war_preparation
-					}
+					has_idea = ROM_war_preparation
 				}
 			}
 			HUN = {
 				NOT = {
-					has_idea = {
-						HUN_war_preparation
-					}
+					has_idea = HUN_war_preparation
 				}
 			}
 		}

--- a/localisation/ihmp_events_l_english.yml
+++ b/localisation/ihmp_events_l_english.yml
@@ -22,3 +22,4 @@
  panay_incident.5.a.tt:0 "This will allow us to pass Two Ocean Navy act with high congress support regardless of other requirements!"
  GER_integrate_war_economies_tt5:2 "If §Y[BUL.GetName]§! is in a faction with §Y[Root.GetName]§!, add §Y4 Military Factory§! each to §Y[Root.GetName]§! and §Y[BUL.GetName]§!, and §Y[BUL.GetName]§! becomes puppet of §Y[Root.GetName]§!.\n"
  GER_integrate_war_economies_tt6:0 "§R[BUL.GetName] must approve of the agreement for the bonuses to take effect.§!\n"
+ DOD_hungary.54.d:0 "The conflict was already resolved."

--- a/localisation/ihmp_events_l_german.yml
+++ b/localisation/ihmp_events_l_german.yml
@@ -22,3 +22,4 @@
  panay_incident.5.a.tt:0 "This will allow us to pass Two Ocean Navy act with high congress support regardless of other requirements!"
  GER_integrate_war_economies_tt5:2 "If §Y[BUL.GetName]§! is in a faction with §Y[Root.GetName]§!, add §Y4 Military Factory§! each to §Y[Root.GetName]§! and §Y[BUL.GetName]§!, and §Y[BUL.GetName]§! becomes puppet of §Y[Root.GetName]§!.\n"
  GER_integrate_war_economies_tt6:0 "§R[BUL.GetName] must approve of the agreement for the bonuses to take effect.§!\n"
+ DOD_hungary.54.d:0 "Der Konflikt wurde bereits gelöst."


### PR DESCRIPTION
Added a fix for the DoD.hungary eventchain for demand Transylvania

Only fire event 54, if noone intervenes (limit not = {intervene_limit}).

If someone intervenes on event 60, but then decide to let them work it out (option c) then event 54 also get fired.
If multiple nations intervene, it is enough if just one nation picks option c there.

Dirty fix for event 54. Added a 4th option (d). Even if event 54 fires, with the 4th option nothing happens if the conflict is already resolved (NOT = has_idea =  war_preparations).

Still breaks, if Hungary doesn't decide for an option for the intervention event happens in 72h.
Should be fine for IHMP though.