### PR TITLE
Updatet France.txt eventfile surrenderprogress for vichy from >0.7 to >0.4

### DIFF
--- a/events/France.txt
+++ b/events/France.txt
@@ -184,7 +184,7 @@ country_event = {
 		16 = { is_controlled_by = GER }
 		is_in_faction_with = ENG
 		ENG = { has_war_with = GER }
-		surrender_progress > 0.7
+		surrender_progress > 0.4
 		GER = {
 			OR = {
 				is_faction_leader = yes


### PR DESCRIPTION
Since France gets rid of disjointed goverment, they have a higher surrenderlimit.
Changed the condition in the hidden preevent

#hidden pre-event to check before capitulation
country_event = {
	id = france.101

from
surrender_progress > 0.7
to
surrender_progress > 0.4

France without disjointed goverment is roughly 41% surrendering, when they lost Le Havre and Paris, german frontline along the river. But Reims still in French hands.

This allows the decision for an early easy Vichy when you get Paris, or the decision to fight on for a long battle to get all of France.