### PR TITLE
Fixed Bypass for Italian Focus ITA_victoryinETH

### DIFF
--- a/common/national_focus/italy.txt
+++ b/common/national_focus/italy.txt
@@ -1564,6 +1564,7 @@ focus_tree = {
 		bypass = {
 			ETH = { exists = yes }
 			NOT = { has_war_with = ETH }
+			NOT = { ETH = { is_subject_of = ITA } }
 		}
 
 		available_if_capitulated = yes


### PR DESCRIPTION
Added the condition
NOT = { ETH = { is_subject_of = ITA } }
for the bypass for the focus ITA_victoryinETH, so it doesn't get bypassed if Italy puppeted Ethopia (it exists and Italy is in peace with eth)