### PR TITLE
Focus Factory Placement for GER and ENG

### DIFF
--- a/common/national_focus/germany.txt
+++ b/common/national_focus/germany.txt
@@ -1483,6 +1483,8 @@ focus_tree = {
 			}
 			random_owned_controlled_state = {
 				limit = {
+					ROOT = { has_full_control_of_state = PREV }
+					is_core_of = ROOT
 					free_building_slots = {
 						building = arms_factory
 						size > 1
@@ -1499,6 +1501,8 @@ focus_tree = {
 			}
 			random_owned_controlled_state = {
 				limit = {
+					ROOT = { has_full_control_of_state = PREV }
+					is_core_of = ROOT
 					free_building_slots = {
 						building = arms_factory
 						size > 1
@@ -1515,6 +1519,8 @@ focus_tree = {
 			}
 			random_owned_controlled_state = {
 				limit = {
+					ROOT = { has_full_control_of_state = PREV }
+					is_core_of = ROOT
 					free_building_slots = {
 						building = arms_factory
 						size > 1
@@ -1893,6 +1899,8 @@ focus_tree = {
 				effect_tooltip = {
 					random_owned_controlled_state = {
 						limit = {
+							ROOT = { has_full_control_of_state = PREV }
+							is_core_of = ROOT
 							free_building_slots = {
 								building = arms_factory
 								size > 1
@@ -1910,6 +1918,8 @@ focus_tree = {
 					}
 					random_owned_controlled_state = {
 						limit = {
+							ROOT = { has_full_control_of_state = PREV }
+							is_core_of = ROOT
 							free_building_slots = {
 								building = arms_factory
 								size > 1
@@ -1928,6 +1938,8 @@ focus_tree = {
 					HUN = {
 						random_owned_controlled_state = {
 							limit = {
+							ROOT = { has_full_control_of_state = PREV }
+							is_core_of = ROOT
 								free_building_slots = {
 									building = arms_factory
 									size > 1
@@ -1944,6 +1956,8 @@ focus_tree = {
 						}
 						random_owned_controlled_state = {
 							limit = {
+							ROOT = { has_full_control_of_state = PREV }
+							is_core_of = ROOT
 								free_building_slots = {
 									building = arms_factory
 									size > 1
@@ -1993,6 +2007,8 @@ focus_tree = {
 				effect_tooltip = {
 					random_owned_controlled_state = {
 						limit = {
+							ROOT = { has_full_control_of_state = PREV }
+							is_core_of = ROOT
 							free_building_slots = {
 								building = arms_factory
 								size > 1
@@ -2010,6 +2026,8 @@ focus_tree = {
 					}
 					random_owned_controlled_state = {
 						limit = {
+							ROOT = { has_full_control_of_state = PREV }
+							is_core_of = ROOT
 							free_building_slots = {
 								building = arms_factory
 								size > 1
@@ -2028,6 +2046,11 @@ focus_tree = {
 					ROM = {
 						random_owned_controlled_state = {
 							limit = {
+							ROOT = { has_full_control_of_state = PREV }
+							is_core_of = ROOT
+							NOT = { state = 78 }
+							NOT = { state = 80 }
+							NOT = { state = 766 }
 								free_building_slots = {
 									building = arms_factory
 									size > 1
@@ -2044,6 +2067,11 @@ focus_tree = {
 						}
 						random_owned_controlled_state = {
 							limit = {
+							ROOT = { has_full_control_of_state = PREV }
+							is_core_of = ROOT
+							NOT = { state = 78 }
+							NOT = { state = 80 }
+							NOT = { state = 766 }
 								free_building_slots = {
 									building = arms_factory
 									size > 1
@@ -2093,6 +2121,8 @@ focus_tree = {
 				effect_tooltip = {
 					random_owned_controlled_state = {
 						limit = {
+							ROOT = { has_full_control_of_state = PREV }
+							is_core_of = ROOT
 							free_building_slots = {
 								building = arms_factory
 								size > 1
@@ -2110,6 +2140,8 @@ focus_tree = {
 					}
 					random_owned_controlled_state = {
 						limit = {
+							ROOT = { has_full_control_of_state = PREV }
+							is_core_of = ROOT
 							free_building_slots = {
 								building = arms_factory
 								size > 1
@@ -2127,6 +2159,8 @@ focus_tree = {
 					}
 					BUL = {
 						random_owned_controlled_state = {
+							ROOT = { has_full_control_of_state = PREV }
+							is_core_of = ROOT
 							limit = {
 								free_building_slots = {
 									building = arms_factory
@@ -2144,6 +2178,8 @@ focus_tree = {
 						}
 						random_owned_controlled_state = {
 							limit = {
+							ROOT = { has_full_control_of_state = PREV }
+							is_core_of = ROOT
 								free_building_slots = {
 									building = arms_factory
 									size > 1
@@ -4340,8 +4376,8 @@ focus_tree = {
 						original_tag = SPR
 						has_government = fascism
 					}
-					remove_ideas = SPA_recovering_from_civil_war
 					add_opinion_modifier = { target = GER modifier = ger_spa_alliance_focus }
+					set_country_flag = ger_spa_alliance_focus
 				}
 			}
 			if = {
@@ -4349,8 +4385,8 @@ focus_tree = {
 					has_dlc = "La Resistance"
 				}
 				SPA = {
-					remove_ideas = SPA_recovering_from_civil_war
 					add_opinion_modifier = { target = GER modifier = ger_spa_alliance_focus }
+					set_country_flag = ger_spa_alliance_focus
 				}
 			}
 		}
@@ -4649,6 +4685,8 @@ focus_tree = {
 		completion_reward = {
 			random_owned_controlled_state = {
 				limit = {
+					ROOT = { has_full_control_of_state = PREV }
+					is_core_of = ROOT
 					dockyard > 0
 					free_building_slots = {
 						building = dockyard
@@ -4666,6 +4704,8 @@ focus_tree = {
 			}
 			random_owned_controlled_state = {
 				limit = {
+					ROOT = { has_full_control_of_state = PREV }
+					is_core_of = ROOT
 					dockyard > 0
 					free_building_slots = {
 						building = dockyard
@@ -4729,6 +4769,8 @@ focus_tree = {
 			navy_experience = 25
 			random_owned_controlled_state = {
 				limit = {
+					ROOT = { has_full_control_of_state = PREV }
+					is_core_of = ROOT
 					dockyard > 0
 					free_building_slots = {
 						building = dockyard
@@ -4789,6 +4831,8 @@ focus_tree = {
 		completion_reward = {
 			random_owned_controlled_state = {
 				limit = {
+					ROOT = { has_full_control_of_state = PREV }
+					is_core_of = ROOT
 					dockyard > 0
 					free_building_slots = {
 						building = dockyard
@@ -4807,6 +4851,8 @@ focus_tree = {
 			}
 			random_owned_controlled_state = {
 				limit = {
+					ROOT = { has_full_control_of_state = PREV }
+					is_core_of = ROOT
 					dockyard > 0
 					free_building_slots = {
 						building = dockyard
@@ -4877,6 +4923,8 @@ focus_tree = {
 			navy_experience = 50
 			random_owned_controlled_state = {
 				limit = {
+					ROOT = { has_full_control_of_state = PREV }
+					is_core_of = ROOT
 					dockyard > 0
 					free_building_slots = {
 						building = dockyard
@@ -4958,6 +5006,8 @@ focus_tree = {
 			navy_experience = 25
 			random_owned_controlled_state = {
 				limit = {
+					ROOT = { has_full_control_of_state = PREV }
+					is_core_of = ROOT
 					dockyard > 0
 					free_building_slots = {
 						building = dockyard

--- a/common/national_focus/uk.txt
+++ b/common/national_focus/uk.txt
@@ -185,12 +185,13 @@ focus_tree = {
 		completion_reward = {
 			random_owned_controlled_state = {
 				limit = {
+					ROOT = { has_full_control_of_state = PREV }
+					is_core_of = ROOT
 					free_building_slots = {
 						building = industrial_complex
 						size > 1
 						include_locked = yes
 					}
-					is_core_of = ROOT
 				}
 				add_extra_state_shared_building_slots = 2
 				add_building_construction = {
@@ -202,12 +203,13 @@ focus_tree = {
 			}
 			random_owned_controlled_state = {
 				limit = {
+					ROOT = { has_full_control_of_state = PREV }
+					is_core_of = ROOT
 					free_building_slots = {
 						building = industrial_complex
 						size > 1
 						include_locked = yes
 					}
-					is_core_of = ROOT
 				}
 				add_extra_state_shared_building_slots = 2
 				add_building_construction = {
@@ -807,6 +809,8 @@ focus_tree = {
 		completion_reward = {
 			random_owned_controlled_state = {
 				limit = {
+					ROOT = { has_full_control_of_state = PREV }
+					is_core_of = ROOT
 					is_in_home_area = yes
 					free_building_slots = {
 						building = arms_factory
@@ -824,6 +828,8 @@ focus_tree = {
 			}
 			random_owned_controlled_state = {
 				limit = {
+					ROOT = { has_full_control_of_state = PREV }
+					is_core_of = ROOT
 					is_in_home_area = yes
 					free_building_slots = {
 						building = arms_factory
@@ -841,6 +847,8 @@ focus_tree = {
 			}
 			random_owned_controlled_state = {
 				limit = {
+					ROOT = { has_full_control_of_state = PREV }
+					is_core_of = ROOT
 					is_in_home_area = yes
 					free_building_slots = {
 						building = arms_factory
@@ -1309,13 +1317,14 @@ focus_tree = {
 			navy_experience = 50
 			random_owned_controlled_state = {
 				limit = {
+					ROOT = { has_full_control_of_state = PREV }
+					is_core_of = ROOT
 					is_coastal = yes
 					free_building_slots = {
 						building = dockyard
 						size > 0
 						include_locked = yes
 					}
-					is_core_of = ROOT
 				}
 				add_extra_state_shared_building_slots = 1
 				add_building_construction = {
@@ -1327,13 +1336,14 @@ focus_tree = {
 			}
 			random_owned_controlled_state = {
 				limit = {
+					ROOT = { has_full_control_of_state = PREV }
+					is_core_of = ROOT
 					is_coastal = yes
 					free_building_slots = {
 						building = dockyard
 						size > 0
 						include_locked = yes
 					}
-					is_core_of = ROOT
 				}
 				add_extra_state_shared_building_slots = 1
 				add_building_construction = {
@@ -1345,13 +1355,14 @@ focus_tree = {
 			}
 			random_owned_controlled_state = {
 				limit = {
+					ROOT = { has_full_control_of_state = PREV }
+					is_core_of = ROOT
 					is_coastal = yes
 					free_building_slots = {
 						building = dockyard
 						size > 0
 						include_locked = yes
 					}
-					is_core_of = ROOT
 				}
 				add_extra_state_shared_building_slots = 1
 				add_building_construction = {
@@ -1701,13 +1712,14 @@ focus_tree = {
 		completion_reward = {
 			random_owned_controlled_state = {
 				limit = {
+					ROOT = { has_full_control_of_state = PREV }
+					is_core_of = ROOT
 					is_coastal = yes
 					free_building_slots = {
 						building = dockyard
 						size > 1
 						include_locked = yes
 					}
-					is_core_of = ROOT
 				}
 				add_extra_state_shared_building_slots = 2
 				add_building_construction = {
@@ -2085,7 +2097,7 @@ focus_tree = {
 			POR = { is_in_faction = no }
 			is_faction_leader = yes
 		} 
-		icon = GFX_focus_generic_befriend_portugal
+		icon = GFX_goal_generic_demand_territory
 		x = -1
 		y = 1
 		relative_position_id = uk_mediterranean_focus
@@ -5632,6 +5644,10 @@ focus_tree = {
 				add_opinion_modifier = { target = ENG modifier = aided_industry }
 				random_owned_controlled_state = {
 					limit = {
+						RAJ = { has_full_control_of_state = PREV }
+						is_core_of = RAJ
+						NOT = { is_core_of = PAK }
+						NOT = { is_core_of = BAN }
 						free_building_slots = {
 							building = industrial_complex
 							size > 1
@@ -5648,6 +5664,10 @@ focus_tree = {
 				}
 				random_owned_controlled_state = {
 					limit = {
+						RAJ = { has_full_control_of_state = PREV }
+						is_core_of = RAJ
+						NOT = { is_core_of = PAK }
+						NOT = { is_core_of = BAN }
 						free_building_slots = {
 							building = industrial_complex
 							size > 1
@@ -5664,6 +5684,10 @@ focus_tree = {
 				}
 				random_owned_controlled_state = {
 					limit = {
+						RAJ = { has_full_control_of_state = PREV }
+						is_core_of = RAJ
+						NOT = { is_core_of = PAK }
+						NOT = { is_core_of = BAN }
 						free_building_slots = {
 							building = industrial_complex
 							size > 0
@@ -5842,6 +5866,8 @@ focus_tree = {
 				add_opinion_modifier = { target = ENG modifier = aided_industry }
 				random_owned_controlled_state = {
 					limit = {
+						AST = { has_full_control_of_state = PREV }
+						is_core_of = AST
 						free_building_slots = {
 							building = industrial_complex
 							size > 0
@@ -5858,6 +5884,8 @@ focus_tree = {
 				}
 				random_owned_controlled_state = {
 					limit = {
+						AST = { has_full_control_of_state = PREV }
+						is_core_of = AST
 						free_building_slots = {
 							building = industrial_complex
 							size > 0
@@ -5874,6 +5902,8 @@ focus_tree = {
 				}
 				random_owned_controlled_state = {
 					limit = {
+						AST = { has_full_control_of_state = PREV }
+						is_core_of = AST
 						is_coastal = yes
 						free_building_slots = {
 							building = dockyard
@@ -5891,6 +5921,8 @@ focus_tree = {
 				}
 				random_owned_controlled_state = {
 					limit = {
+						AST = { has_full_control_of_state = PREV }
+						is_core_of = AST
 						is_coastal = yes
 						free_building_slots = {
 							building = dockyard
@@ -6002,6 +6034,8 @@ focus_tree = {
 				add_opinion_modifier = { target = ENG modifier = aided_industry }
 				random_owned_controlled_state = {
 					limit = {
+						NZL = { has_full_control_of_state = PREV }
+						is_core_of = NZL
 						free_building_slots = {
 							building = industrial_complex
 							size > 0
@@ -6018,6 +6052,8 @@ focus_tree = {
 				}
 				random_owned_controlled_state = {
 					limit = {
+						NZL = { has_full_control_of_state = PREV }
+						is_core_of = NZL
 						free_building_slots = {
 							building = industrial_complex
 							size > 0
@@ -6034,6 +6070,8 @@ focus_tree = {
 				}
 				random_owned_controlled_state = {
 					limit = {
+						NZL = { has_full_control_of_state = PREV }
+						is_core_of = NZL
 						is_coastal = yes
 						free_building_slots = {
 							building = dockyard
@@ -6051,6 +6089,8 @@ focus_tree = {
 				}
 				random_owned_controlled_state = {
 					limit = {
+						NZL = { has_full_control_of_state = PREV }
+						is_core_of = NZL
 						is_coastal = yes
 						free_building_slots = {
 							building = dockyard
@@ -6162,6 +6202,8 @@ focus_tree = {
 				add_opinion_modifier = { target = ENG modifier = aided_industry }
 				random_owned_controlled_state = {
 					limit = {
+						CAN = { has_full_control_of_state = PREV }
+						is_core_of = CAN
 						free_building_slots = {
 							building = industrial_complex
 							size > 1
@@ -6178,6 +6220,8 @@ focus_tree = {
 				}
 				random_owned_controlled_state = {
 					limit = {
+						CAN = { has_full_control_of_state = PREV }
+						is_core_of = CAN
 						free_building_slots = {
 							building = industrial_complex
 							size > 0
@@ -6194,6 +6238,8 @@ focus_tree = {
 				}
 				random_owned_controlled_state = {
 					limit = {
+						CAN = { has_full_control_of_state = PREV }
+						is_core_of = CAN
 						is_coastal = yes
 						free_building_slots = {
 							building = dockyard
@@ -6211,6 +6257,8 @@ focus_tree = {
 				}
 				random_owned_controlled_state = {
 					limit = {
+						CAN = { has_full_control_of_state = PREV }
+						is_core_of = CAN
 						is_coastal = yes
 						free_building_slots = {
 							building = dockyard
@@ -6321,6 +6369,8 @@ focus_tree = {
 				add_opinion_modifier = { target = ENG modifier = aided_industry }
 				random_owned_controlled_state = {
 					limit = {
+						SAF = { has_full_control_of_state = PREV }
+						is_core_of = SAF
 						free_building_slots = {
 							building = industrial_complex
 							size > 1
@@ -6353,6 +6403,8 @@ focus_tree = {
 				}
 				random_owned_controlled_state = {
 					limit = {
+						SAF = { has_full_control_of_state = PREV }
+						is_core_of = SAF
 						is_coastal = yes
 						free_building_slots = {
 							building = dockyard
@@ -6370,6 +6422,8 @@ focus_tree = {
 				}
 				random_owned_controlled_state = {
 					limit = {
+						SAF = { has_full_control_of_state = PREV }
+						is_core_of = SAF
 						is_coastal = yes
 						free_building_slots = {
 							building = dockyard
@@ -7472,6 +7526,8 @@ focus_tree = {
 		completion_reward = {
 			random_owned_controlled_state = {
 				limit = {
+					ROOT = { has_full_control_of_state = PREV }
+					is_core_of = ROOT
 					is_in_home_area = yes
 					free_building_slots = {
 						building = arms_factory
@@ -7489,6 +7545,8 @@ focus_tree = {
 			}
 			random_owned_controlled_state = {
 				limit = {
+					ROOT = { has_full_control_of_state = PREV }
+					is_core_of = ROOT
 					is_in_home_area = yes
 					free_building_slots = {
 						building = arms_factory


### PR DESCRIPTION
Updated Integrated/German War Economy and Develop Colonies Foci with spawned factories restricted to cores of target nations.

Be careful of merging UK Focus Tree file, I used old file before you changed the focus icon for Invoke Portugal Alliance.