### PR TITLE
Suez- Rebuild Stages, Destroy Stages, Destroy Full.

### DIFF
--- a/common/decisions/_generic_decisions.txt
+++ b/common/decisions/_generic_decisions.txt
@@ -1018,7 +1018,9 @@ operations = {
 	
 		visible = {
 			has_war = yes
-			NOT = { has_global_flag = SUEZ_CANAL_BLOCKED }
+			NOT = { 
+					has_global_flag = SUEZ_CANAL_BLOCKED 
+			}
 			any_controlled_state = {
 				OR = {
 					region = 28
@@ -1067,7 +1069,20 @@ operations = {
 				}
 				set_country_flag = blew_up_suez
 				set_global_flag = SUEZ_CANAL_BLOCKED
+				set_global_flag = SUEZ_CANAL_BLOCKED_0
 				country_event = { id = wtt_news.40 hours = 6}
+				remove_province_modifier = {
+					static_modifiers = { suez_level_10 }
+					province = { 
+						4073
+					}
+				}
+				add_province_modifier = {
+					static_modifiers = { suez_level_0 }
+					province = { 
+						4073
+					}
+				}
 			}
 			effect_tooltip = {
 				if = {
@@ -1076,6 +1091,387 @@ operations = {
 							owns_state = 446
 							owns_state = 453
 						}
+					}
+					add_war_support = -0.05
+					add_stability = -0.05
+				}
+			}
+		}
+		ai_will_do = {
+			factor = 0
+			modifier = {
+				factor = 0
+				NOT = {
+					any_enemy_country = {
+						OR = {
+							controls_state = 452
+							controls_state = 447
+							controls_state = 456
+							controls_state = 457
+							controls_state = 454
+							controls_state = 455
+							OR = {
+								divisions_in_state = { state = 454 size > 2 }
+								divisions_in_state = { state = 447 size > 2 }
+								divisions_in_state = { state = 457 size > 2 }
+								divisions_in_state = { state = 456 size > 2 }
+							}
+						}
+					}
+				}
+			}
+			modifier = {
+				factor = 0 # Don't blow the canal when you've got troops needing supplies in the Horn of Africa, and no land route has been established there
+				any_allied_country = {
+					NOT = {
+						OR = {
+							has_full_control_of_state = 457
+							has_full_control_of_state = 456
+						}
+					}
+					NOT = { has_full_control_of_state = 551 }
+					OR = {
+						divisions_in_state = { state = 550 size > 0 }
+						divisions_in_state = { state = 268 size > 0 }
+						divisions_in_state = { state = 269 size > 0 }
+						divisions_in_state = { state = 559 size > 0 }
+					}
+				}
+			}
+			modifier = {
+				factor = 200 # Try to cut the enemy off from the mediterranean if you also occupy Gibraltar
+				OR = {
+					has_full_control_of_state = 118
+					any_allied_country = {
+						has_full_control_of_state = 118
+					}
+				}
+				has_war = yes
+				NOT = { tag = ENG }
+			}
+		}
+	}
+
+	blow_suez_canal_iteration = {
+
+		icon = GFX_decision_generic_ignite_civil_war
+		allowed = {
+			has_dlc = "Waking the Tiger"
+		}
+		available = {
+			controls_state = 446
+			controls_state = 453
+			OR = {
+				NOT = {
+					owns_state = 446
+					owns_state = 453
+				}
+				any_enemy_country = {
+					OR = {
+						controls_state = 452
+						controls_state = 447
+						controls_state = 456
+						controls_state = 457
+						controls_state = 454
+						controls_state = 455
+					}
+				}
+			}
+		}
+	
+		visible = {
+			has_war = yes
+			any_controlled_state = {
+				OR = {
+					region = 28
+					region = 128
+				}
+			}
+		}
+	
+		fire_only_once = no
+	
+		days_remove = 8
+	
+		cost = 10
+	
+		modifier = {
+			civilian_factory_use = 5
+		}
+
+		complete_effect = {
+			hidden_effect = {
+				if = {
+					limit = {
+						NOT = {
+							owns_state = 446
+							owns_state = 453
+						}
+					}
+					random_country = {
+						limit = {
+							owns_state = 446
+							owns_state = 453
+						}
+						country_event = { id = generic.12 days = 1 }
+					}
+				}
+			}
+		}
+	
+		remove_effect = {
+			if = {
+				limit = {
+					OR = {
+						has_full_control_of_state = 446
+						has_full_control_of_state = 453
+					}
+					NOT = {
+						has_country_flag = blew_up_suez
+						has_global_flag = SUEZ_CANAL_BLOCKED
+					}
+				}
+				set_country_flag = blew_up_suez
+				set_global_flag = SUEZ_CANAL_BLOCKED
+				set_global_flag = SUEZ_CANAL_BLOCKED_9
+				country_event = { id = wtt_news.40 hours = 6}
+				remove_province_modifier = {
+					static_modifiers = { suez_level_10 }
+					province = { 
+						4073
+					}
+				}
+				add_province_modifier = {
+					static_modifiers = { suez_level_9 }
+					province = { 
+						4073
+					}
+				}
+			}
+			else_if = {
+				limit = {
+					OR = {
+						has_full_control_of_state = 446
+						has_full_control_of_state = 453
+					}
+					has_global_flag = SUEZ_CANAL_BLOCKED
+					has_global_flag = SUEZ_CANAL_BLOCKED_9
+				}
+				clr_global_flag = SUEZ_CANAL_BLOCKED_9
+				set_global_flag = SUEZ_CANAL_BLOCKED_8
+				remove_province_modifier = {
+					static_modifiers = { suez_level_9 }
+					province = { 
+						4073
+					}
+				}
+				add_province_modifier = {
+					static_modifiers = { suez_level_8 }
+					province = { 
+						4073
+					}
+				}
+			}
+			else_if = {
+				limit = {
+					OR = {
+						has_full_control_of_state = 446
+						has_full_control_of_state = 453
+					}
+					has_global_flag = SUEZ_CANAL_BLOCKED
+					has_global_flag = SUEZ_CANAL_BLOCKED_8
+				}
+				clr_global_flag = SUEZ_CANAL_BLOCKED_8
+				set_global_flag = SUEZ_CANAL_BLOCKED_7
+				remove_province_modifier = {
+					static_modifiers = { suez_level_8 }
+					province = { 
+						4073
+					}
+				}
+				add_province_modifier = {
+					static_modifiers = { suez_level_7 }
+					province = { 
+						4073
+					}
+				}
+			}
+			else_if = {
+				limit = {
+					OR = {
+						has_full_control_of_state = 446
+						has_full_control_of_state = 453
+					}
+					has_global_flag = SUEZ_CANAL_BLOCKED
+					has_global_flag = SUEZ_CANAL_BLOCKED_7
+				}
+				clr_global_flag = SUEZ_CANAL_BLOCKED_7
+				set_global_flag = SUEZ_CANAL_BLOCKED_6
+				remove_province_modifier = {
+					static_modifiers = { suez_level_7 }
+					province = { 
+						4073
+					}
+				}
+				add_province_modifier = {
+					static_modifiers = { suez_level_6 }
+					province = { 
+						4073
+					}
+				}
+			}
+			else_if = {
+				limit = {
+					OR = {
+						has_full_control_of_state = 446
+						has_full_control_of_state = 453
+					}
+					has_global_flag = SUEZ_CANAL_BLOCKED
+					has_global_flag = SUEZ_CANAL_BLOCKED_6
+				}
+				clr_global_flag = SUEZ_CANAL_BLOCKED_6
+				set_global_flag = SUEZ_CANAL_BLOCKED_5
+				remove_province_modifier = {
+					static_modifiers = { suez_level_6 }
+					province = { 
+						4073
+					}
+				}
+				add_province_modifier = {
+					static_modifiers = { suez_level_5 }
+					province = { 
+						4073
+					}
+				}
+			}
+			else_if = {
+				limit = {
+					OR = {
+						has_full_control_of_state = 446
+						has_full_control_of_state = 453
+					}
+					has_global_flag = SUEZ_CANAL_BLOCKED
+					has_global_flag = SUEZ_CANAL_BLOCKED_5
+				}
+				clr_global_flag = SUEZ_CANAL_BLOCKED_5
+				set_global_flag = SUEZ_CANAL_BLOCKED_4
+				remove_province_modifier = {
+					static_modifiers = { suez_level_5 }
+					province = { 
+						4073
+					}
+				}
+				add_province_modifier = {
+					static_modifiers = { suez_level_4 }
+					province = { 
+						4073
+					}
+				}
+			}
+			else_if = {
+				limit = {
+					OR = {
+						has_full_control_of_state = 446
+						has_full_control_of_state = 453
+					}
+					has_global_flag = SUEZ_CANAL_BLOCKED
+					has_global_flag = SUEZ_CANAL_BLOCKED_4
+				}
+				clr_global_flag = SUEZ_CANAL_BLOCKED_4
+				set_global_flag = SUEZ_CANAL_BLOCKED_3
+				remove_province_modifier = {
+					static_modifiers = { suez_level_4 }
+					province = { 
+						4073
+					}
+				}
+				add_province_modifier = {
+					static_modifiers = { suez_level_3 }
+					province = { 
+						4073
+					}
+				}
+			}
+			else_if = {
+				limit = {
+					OR = {
+						has_full_control_of_state = 446
+						has_full_control_of_state = 453
+					}
+					has_global_flag = SUEZ_CANAL_BLOCKED
+					has_global_flag = SUEZ_CANAL_BLOCKED_3
+				}
+				clr_global_flag = SUEZ_CANAL_BLOCKED_3
+				set_global_flag = SUEZ_CANAL_BLOCKED_2
+				remove_province_modifier = {
+					static_modifiers = { suez_level_3 }
+					province = { 
+						4073
+					}
+				}
+				add_province_modifier = {
+					static_modifiers = { suez_level_2 }
+					province = { 
+						4073
+					}
+				}
+			}
+			else_if = {
+				limit = {
+					OR = {
+						has_full_control_of_state = 446
+						has_full_control_of_state = 453
+					}
+					has_global_flag = SUEZ_CANAL_BLOCKED
+					has_global_flag = SUEZ_CANAL_BLOCKED_2
+				}
+				clr_global_flag = SUEZ_CANAL_BLOCKED_2
+				set_global_flag = SUEZ_CANAL_BLOCKED_1
+				remove_province_modifier = {
+					static_modifiers = { suez_level_2 }
+					province = { 
+						4073
+					}
+				}
+				add_province_modifier = {
+					static_modifiers = { suez_level_1 }
+					province = { 
+						4073
+					}
+				}
+			}
+			else_if = {
+				limit = {
+					OR = {
+						has_full_control_of_state = 446
+						has_full_control_of_state = 453
+					}
+					has_global_flag = SUEZ_CANAL_BLOCKED
+					has_global_flag = SUEZ_CANAL_BLOCKED_1
+				}
+				clr_global_flag = SUEZ_CANAL_BLOCKED_1
+				set_global_flag = SUEZ_CANAL_BLOCKED_0
+				remove_province_modifier = {
+					static_modifiers = { suez_level_1 }
+					province = { 
+						4073
+					}
+				}
+				add_province_modifier = {
+					static_modifiers = { suez_level_0 }
+					province = { 
+						4073
+					}
+				}
+			}
+			effect_tooltip = {
+				if = {
+					limit = {
+						ENG = {
+							owns_state = 446
+							owns_state = 453
+						}
+						NOT = { has_country_flag = blew_up_suez }
 					}
 					add_war_support = -0.05
 					add_stability = -0.05
@@ -1249,21 +1645,33 @@ special_projects = {
 		available = {
 			has_full_control_of_state = 446
 			has_full_control_of_state = 453
-			num_of_civilian_factories > 10
+			num_of_civilian_factories > 15
 		}
 	
 		visible = {
 			has_global_flag = SUEZ_CANAL_BLOCKED
+			OR = {
+				has_global_flag = SUEZ_CANAL_BLOCKED_0
+				has_global_flag = SUEZ_CANAL_BLOCKED_1
+				has_global_flag = SUEZ_CANAL_BLOCKED_2
+				has_global_flag = SUEZ_CANAL_BLOCKED_3
+				has_global_flag = SUEZ_CANAL_BLOCKED_4
+				has_global_flag = SUEZ_CANAL_BLOCKED_5
+				has_global_flag = SUEZ_CANAL_BLOCKED_6
+				has_global_flag = SUEZ_CANAL_BLOCKED_7
+				has_global_flag = SUEZ_CANAL_BLOCKED_8
+				has_global_flag = SUEZ_CANAL_BLOCKED_9
+			}
 		}
 	
 		fire_only_once = no
 	
-		days_remove = 365
+		days_remove = 31	#365
 	
-		cost = 120
+		cost = 15	#120
 	
 		modifier = {
-			civilian_factory_use = 10
+			civilian_factory_use = 15
 		}
 	
 		remove_effect = {
@@ -1271,10 +1679,212 @@ special_projects = {
 				limit = {
 					has_full_control_of_state = 446
 					has_full_control_of_state = 453
+					has_global_flag = SUEZ_CANAL_BLOCKED_9
 				}
 				set_country_flag = rebuilt_suez
 				clr_global_flag = SUEZ_CANAL_BLOCKED
 				country_event = { id = wtt_news.42 hours = 6}
+				remove_province_modifier = {
+					static_modifiers = { suez_level_9 }
+					province = { 
+						4073
+					}
+				}
+				add_province_modifier = {
+					static_modifiers = { suez_level_10 }
+					province = { 
+						4073
+					}
+				}
+			}
+			else_if = {
+				limit = {
+					has_full_control_of_state = 446
+					has_full_control_of_state = 453
+					has_global_flag = SUEZ_CANAL_BLOCKED_8
+				}
+				clr_global_flag = SUEZ_CANAL_BLOCKED_8
+				set_global_flag = SUEZ_CANAL_BLOCKED_9
+				remove_province_modifier = {
+					static_modifiers = { suez_level_8 }
+					province = { 
+						4073
+					}
+				}
+				add_province_modifier = {
+					static_modifiers = { suez_level_9 }
+					province = { 
+						4073
+					}
+				}
+			}
+			else_if = {
+				limit = {
+					has_full_control_of_state = 446
+					has_full_control_of_state = 453
+					has_global_flag = SUEZ_CANAL_BLOCKED_7
+				}
+				clr_global_flag = SUEZ_CANAL_BLOCKED_7
+				set_global_flag = SUEZ_CANAL_BLOCKED_8
+				remove_province_modifier = {
+					static_modifiers = { suez_level_7 }
+					province = { 
+						4073
+					}
+				}
+				add_province_modifier = {
+					static_modifiers = { suez_level_8 }
+					province = { 
+						4073
+					}
+				}
+			}
+			else_if = {
+				limit = {
+					has_full_control_of_state = 446
+					has_full_control_of_state = 453
+					has_global_flag = SUEZ_CANAL_BLOCKED_6
+				}
+				clr_global_flag = SUEZ_CANAL_BLOCKED_6
+				set_global_flag = SUEZ_CANAL_BLOCKED_7
+				remove_province_modifier = {
+					static_modifiers = { suez_level_6 }
+					province = { 
+						4073
+					}
+				}
+				add_province_modifier = {
+					static_modifiers = { suez_level_7 }
+					province = { 
+						4073
+					}
+				}
+			}
+			else_if = {
+				limit = {
+					has_full_control_of_state = 446
+					has_full_control_of_state = 453
+					has_global_flag = SUEZ_CANAL_BLOCKED_5
+				}
+				clr_global_flag = SUEZ_CANAL_BLOCKED_5
+				set_global_flag = SUEZ_CANAL_BLOCKED_6
+				remove_province_modifier = {
+					static_modifiers = { suez_level_5 }
+					province = { 
+						4073
+					}
+				}
+				add_province_modifier = {
+					static_modifiers = { suez_level_6 }
+					province = { 
+						4073
+					}
+				}
+			}
+			else_if = {
+				limit = {
+					has_full_control_of_state = 446
+					has_full_control_of_state = 453
+					has_global_flag = SUEZ_CANAL_BLOCKED_4
+				}
+				clr_global_flag = SUEZ_CANAL_BLOCKED_4
+				set_global_flag = SUEZ_CANAL_BLOCKED_5
+				remove_province_modifier = {
+					static_modifiers = { suez_level_4 }
+					province = { 
+						4073
+					}
+				}
+				add_province_modifier = {
+					static_modifiers = { suez_level_5 }
+					province = { 
+						4073
+					}
+				}
+			}
+			else_if = {
+				limit = {
+					has_full_control_of_state = 446
+					has_full_control_of_state = 453
+					has_global_flag = SUEZ_CANAL_BLOCKED_3
+				}
+				clr_global_flag = SUEZ_CANAL_BLOCKED_3
+				set_global_flag = SUEZ_CANAL_BLOCKED_4
+				remove_province_modifier = {
+					static_modifiers = { suez_level_3 }
+					province = { 
+						4073
+					}
+				}
+				add_province_modifier = {
+					static_modifiers = { suez_level_4 }
+					province = { 
+						4073
+					}
+				}
+			}
+			else_if = {
+				limit = {
+					has_full_control_of_state = 446
+					has_full_control_of_state = 453
+					has_global_flag = SUEZ_CANAL_BLOCKED_2
+				}
+				clr_global_flag = SUEZ_CANAL_BLOCKED_2
+				set_global_flag = SUEZ_CANAL_BLOCKED_3
+				remove_province_modifier = {
+					static_modifiers = { suez_level_2 }
+					province = { 
+						4073
+					}
+				}
+				add_province_modifier = {
+					static_modifiers = { suez_level_3 }
+					province = { 
+						4073
+					}
+				}
+			}
+			else_if = {
+				limit = {
+					has_full_control_of_state = 446
+					has_full_control_of_state = 453
+					has_global_flag = SUEZ_CANAL_BLOCKED_1
+				}
+				clr_global_flag = SUEZ_CANAL_BLOCKED_1
+				set_global_flag = SUEZ_CANAL_BLOCKED_2
+				remove_province_modifier = {
+					static_modifiers = { suez_level_1 }
+					province = { 
+						4073
+					}
+				}
+				add_province_modifier = {
+					static_modifiers = { suez_level_2 }
+					province = { 
+						4073
+					}
+				}
+			}
+			else_if = {
+				limit = {
+					has_full_control_of_state = 446
+					has_full_control_of_state = 453
+					has_global_flag = SUEZ_CANAL_BLOCKED_0
+				}
+				clr_global_flag = SUEZ_CANAL_BLOCKED_0
+				set_global_flag = SUEZ_CANAL_BLOCKED_1
+				remove_province_modifier = {
+					static_modifiers = { suez_level_0 }
+					province = { 
+						4073
+					}
+				}
+				add_province_modifier = {
+					static_modifiers = { suez_level_1 }
+					province = { 
+						4073
+					}
+				}
 			}
 		}
 

--- a/common/modifiers/00_static_modifiers.txt
+++ b/common/modifiers/00_static_modifiers.txt
@@ -125,6 +125,40 @@ unplanned_offensive = { # on Province
 	ground_attack_factor = -0.75
 }
 
+suez_level_10 = {
+	#Dummy
+}
+suez_level_9 = {
+	#Dummy
+}
+suez_level_8 = {
+	#Dummy
+}
+suez_level_7 = {
+	#Dummy
+}
+suez_level_6 = {
+	#Dummy
+}
+suez_level_5 = {
+	#Dummy
+}
+suez_level_4 = {
+	#Dummy
+}
+suez_level_3 = {
+	#Dummy
+}
+suez_level_2 = {
+	#Dummy
+}
+suez_level_1 = {
+	#Dummy
+}
+suez_level_0 = {
+	#Dummy
+}
+
 night = { # On province. Multiplied by amount of darkness.
 	naval_hit_chance = -0.25
 	carrier_traffic = -1.0

--- a/localisation/ihmp_events_l_english.yml
+++ b/localisation/ihmp_events_l_english.yml
@@ -1,4 +1,4 @@
-﻿l_english:
+l_english:
  amm_soviet.1.t:0 "Shocked Forces"
  amm_soviet.1.d:0 "Due to the surprise, speed and ferocity of the Axis invaders our army and airforce is in a state of complete shock"
  amm_soviet.1.a:0 "The Soviet will endure!"
@@ -23,3 +23,5 @@
  GER_integrate_war_economies_tt5:2 "If §Y[BUL.GetName]§! is in a faction with §Y[Root.GetName]§!, add §Y4 Military Factory§! each to §Y[Root.GetName]§! and §Y[BUL.GetName]§!, and §Y[BUL.GetName]§! becomes puppet of §Y[Root.GetName]§!.\n"
  GER_integrate_war_economies_tt6:0 "§R[BUL.GetName] must approve of the agreement for the bonuses to take effect.§!\n"
  DOD_hungary.54.d:0 "The conflict was already resolved."
+ blow_suez_canal_iteration:0 "Damage the Suez Canal"
+ blow_suez_canal_iteration_desc:0 "We  are not confident in our abilities to hold the strategically vital Suez Canal. We must therefore begin preparations to inflict enough partially damage to the canal so that it will remain out of commission for a a short period of time. This will temporarily limit the enemy's ability to move ships from Asia and East Africa into the Mediterranean."


### PR DESCRIPTION
Suez Destruction and Rebuilding. Destruction can be handled as vanilla, with all 10 levels being blown at once, or in stages via the destroy Suez iteration decision.

Suez Rebuilding is done in ten steps, until the Suez is rebuilt. 

The Iterative Destroy and rebuild can work with each other. EX: Country A takes Suez and rebuilds it 5x. Country B can retake Suez and destroy it 2x to leave it at 3x. This means that strategic, temporary offensives to capture and then blow the Suez and then retreat are possible by both sides.