### PR TITLE
Small fix to Continuation war white peace event

### DIFF
--- a/events/Finland.txt
+++ b/events/Finland.txt
@@ -494,6 +494,7 @@ country_event = {
 	trigger = {
 		tag = FIN
 		has_war_with = SOV
+		SOV = { has_war_with = GER }
 		OR = {
 			SOV = {
 				surrender_progress > 0.25


### PR DESCRIPTION
Now for the event to be able to fire, Soviet also needs to be at war with Germany. So the event can't fire in the winter war early.