### PR TITLE
Removed Send Volunteer ai_strategy from Germany and Italy

### DIFF
--- a/common/ai_strategy_plans/GER_MP_plan.txt
+++ b/common/ai_strategy_plans/GER_MP_plan.txt
@@ -210,6 +210,11 @@ GER_MP_Alliance = {
 	}
 	ai_strategy = {
 		type = befriend
+		id = BUL
+		value = 50
+	}
+	ai_strategy = {
+		type = befriend
 		id = ITA
 		value = 200
 	}
@@ -541,35 +546,6 @@ GER_MP_No_Eth = {
 		state = 550 #Eritrea
 		state = 559 #Somaliland (ITA)
 		value = -600
-	}	
-}
-
-GER_MP_Volunteer_Spain = {
-	name = "Volunteers for Spain"
-	desc = ""
-
-	enable = {
-		tag = GER
-		has_game_rule = {
-			rule = GER_ai_behavior
-			option = GER_MP_1
-		}
-		country_exists = SPA
-		NOT = { has_global_flag = scw_over }
-	}
-
-	abort = {
-		OR = {
-			NOT = { country_exists = SPA }
-			SPA = { has_completed_focus = SPA_join_the_allies }
-			has_global_flag = scw_over
-		}
-	}
-	
-	ai_strategy = {
-		type = send_volunteers_desire
-		id = SPA
-		value = 1000
 	}	
 }
 

--- a/common/ai_strategy_plans/ITA_MP_plan.txt
+++ b/common/ai_strategy_plans/ITA_MP_plan.txt
@@ -312,35 +312,6 @@ ITA_MP_No_Eth = {
 	}	
 }
 
-ITA_MP_Volunteer_Spain = {
-	name = "Volunteers for Spain"
-	desc = ""
-
-	enable = {
-		tag = ITA
-		has_game_rule = {
-			rule = ITA_ai_behavior
-			option = ITA_MP_1
-		}
-		country_exists = SPA
-		NOT = { has_global_flag = scw_over }
-	}
-
-	abort = {
-		OR = {
-			NOT = { country_exists = SPA }
-			SPA = { has_completed_focus = SPA_join_the_allies }
-			has_global_flag = scw_over
-		}
-	}
-	
-	ai_strategy = {
-		type = send_volunteers_desire
-		id = SPA
-		value = 1000
-	}	
-}
-
 MP_Conscription_0 = {
 	name = "Conscription Plan"
 	desc = ""


### PR DESCRIPTION
Somewhat a shot in a dark but when I had the error log open in our MP game I saw the error: 
[18:38:52][persistent.cpp:52]: Error: "Malformed token: 19735, near line: 123244" in file: "" near line: 123244

the malformed token 19735 I saw multiple times while the game was running.

The token didn't appear in our current or last week savegame but in the one from 2020/11/09 21:14, so while the game was running.

In this savegame it appears 2 times in ai_strategy. One for Germany one for Italy.
			ai_strategy={ type=34 id=19735 value=1000 }
type=34 ai_strategy is 	send_volunteers_desire strategy says the HoI IV wiki.
So I just removed the send_volunteers_desire ai_strategy from Germany and Italy, potentially this is another ai_strategy not beeing able to be used in ai_strategy_plans, without saying so in the error.log or debug. Doesn't hurt that much to remove it.