### PR TITLE
Improved France AI, reduced randomness, made decision avaible to UK

### DIFF
--- a/common/ai_strategy_plans/FRA_MP_plan.txt
+++ b/common/ai_strategy_plans/FRA_MP_plan.txt
@@ -63,6 +63,15 @@ FRA_MP_1 = {
 		naval_equipment = -1000
 		naval_doctrine = -1000
 	}
+	
+	ai_strategy = {
+		type = put_unit_buffers
+		ratio = 0.2
+		states = {
+			16
+		}
+		area = europe
+	}
 
 	# Keep small, as it is used as a factor for some things (such as research needs)
 	# Recommended around 1.0. Useful for relation between plans
@@ -100,7 +109,7 @@ FRA_MP_2 = {
 		#1937
 		FRA_strengthen_government_support
 		FRA_defensive_strategems
-		FRA_intervention_in_spain
+		#FRA_intervention_in_spain
 		FRA_begin_rearmament
 		FRA_economic_devolution
 		#1938		
@@ -138,6 +147,15 @@ FRA_MP_2 = {
 		naval_doctrine = -1000
 	}
 
+	ai_strategy = {
+		type = put_unit_buffers
+		ratio = 0.2
+		states = {
+			16
+		}
+		area = europe
+	}
+
 	# Keep small, as it is used as a factor for some things (such as research needs)
 	# Recommended around 1.0. Useful for relation between plans
 	weight = {
@@ -170,6 +188,7 @@ FRA_MP_Ideas = {
 	}
 
 	ideas = {
+		war_economy = 0
 		civilian_economy = 0
 		free_trade = 0
 		export_focus = 1
@@ -485,7 +504,7 @@ FRA_MP_AT_Production = {
 	ai_strategy = {
 		type = equipment_production_factor
 		id = armor
-		value = -50
+		value = -100
 	}
 
 }
@@ -607,11 +626,11 @@ FRA_MP_Axis = {
 				option = FRA_MP_2
 			}
 		}
-		date < 1940.1.1
+		date < 1940.6.1
 	}
 
 	abort = {
-		date > 1940.1.1
+		date > 1940.6.1
 	}
 	
 	ai_strategy = {
@@ -627,7 +646,7 @@ FRA_MP_Axis = {
 	ai_strategy = {
 		type = invade
 		id = GER
-		value = -400
+		value = -1000
 	}
 }
 
@@ -647,9 +666,11 @@ FRA_MP_Antagonize = {
 				option = FRA_MP_2
 			}
 		}
+		has_government = democratic
 	}
 
 	abort = {
+		NOT = { has_government = democratic }
 	}
 
 	ai_strategy = {
@@ -677,14 +698,6 @@ FRA_MP_Antagonize = {
 		id = HUN
 		value = 200
 	}
-	ai_strategy = {
-		type = put_unit_buffers
-		ratio = 0.2
-		states = {
-			16
-		}
-		area = europe
-	}
 }
 
 FRA_MP_Allies = {
@@ -711,7 +724,12 @@ FRA_MP_Allies = {
 	ai_strategy = {
 		type = protect
 		id = POL
-		value = 400
+		value = 600
+	}
+	ai_strategy = {
+		type = contain
+		id = GER
+		value = -500
 	}
 	ai_strategy = {
 		type = alliance
@@ -765,7 +783,7 @@ FRA_MP_No_Guarantee = {
 }
 
 FRA_MP_Ignore = {
-	name = "Ignore Baltic for Soviet"
+	name = "Don't contain Soviet"
 	desc = ""
 
 	enable = {
@@ -974,7 +992,7 @@ FRA_MP_Algier_Infrastructure = {
 		type = build_building
 		id = infrastructure
 		target = 459
-		value = 10
+		value = 1
 	}
 }
 
@@ -1026,7 +1044,7 @@ FRA_MP_Civilian_1 = {
 		type = build_building
 		id = industrial_complex
 		target = 459
-		value = 6
+		value = 1
 	}
 }
 

--- a/common/ai_strategy_plans/FREE_FRA_MP_plan.txt
+++ b/common/ai_strategy_plans/FREE_FRA_MP_plan.txt
@@ -9,11 +9,15 @@ FREE_FRA_MP_1 = {
 			option = FREE_FRA_MP_1
 		}
 		has_capitulated = yes
+		has_government = democratic
 	}
 
 	abort = {
-		has_capitulated = no
-		has_completed_focus = FRA_form_the_provisional_government_of_the_republic
+		OR = {
+			has_capitulated = no
+			has_completed_focus = FRA_form_the_provisional_government_of_the_republic
+			NOT = { has_government = democratic }
+		}
 	}
 
 	ai_national_focuses = {
@@ -48,8 +52,8 @@ FREE_FRA_MP_1 = {
 		export_focus = 0
 		limited_exports = 1
 		closed_economy = 0
-		war_economy = 2000
-		partial_economic_mobilisation = 100
+		war_economy = 0
+		partial_economic_mobilisation = 1
 		civilian_economy = 0
 		disarmed_nation = 0
 		volunteer_only = 0
@@ -77,221 +81,5 @@ FREE_FRA_MP_1 = {
 		modifier = {
 			factor = 1.0
 		}
-	}
-}
-
-FRA_MP_NoPlanes = {
-	name = "No Plane Production"
-	desc = ""
-
-	enable = {
-		original_tag = FRA
-		has_game_rule = {
-			rule = FREE_FRA_ai_behavior
-			option = FREE_FRA_MP_1
-		}
-	}
-
-	abort = {
-	}
-
-	ai_strategy = {
-		type = air_factory_balance
-		value = -10000
-	}
-	ai_strategy = {
-		type = equipment_production_factor
-		id = fighter
-		value = -10000
-	}
-	ai_strategy = {
-		type = equipment_production_factor
-		id = cas
-		value = -10000
-	}
-	ai_strategy = {
-		type = equipment_production_factor
-		id = naval_bomber
-		value = -10000
-	}
-	ai_strategy = {
-		type = equipment_production_factor
-		id = tactical_bomber
-		value = -10000
-	}
-	ai_strategy = {
-		type = equipment_production_factor
-		id = strategic_bomber
-		value = -10000
-	}
-	ai_strategy = {
-		type = equipment_production_factor
-		id = scout_plane
-		value = -1000
-	}
-	ai_strategy = {
-		type = unit_ratio
-		id = fighter
-		value = -1000
-	}
-	ai_strategy = {
-		type = unit_ratio
-		id = cas
-		value = -1000
-	}
-	ai_strategy = {
-		type = unit_ratio
-		id = tactical_bomber
-		value = -1000
-	}
-	ai_strategy = {
-		type = unit_ratio
-		id = strategic_bomber
-		value = -1000
-	}
-	ai_strategy = {
-		type = unit_ratio
-		id = naval_bomber
-		value = -1000
-	}
-	ai_strategy = {
-		type = unit_ratio
-		id = scout_plane
-		value = -1000
-	}
-	ai_strategy = {
-		type = unit_ratio
-		id = screen_ship
-		value = -100
-	}
-	ai_strategy = {
-		type = equipment_production_factor
-		id = screen_ship
-		value = -100
-	}
-	ai_strategy = {
-		type = unit_ratio
-		id = submarine
-		value = -100
-	}
-	ai_strategy = {
-		type = equipment_production_factor
-		id = submarine
-		value = -100
-	}
-}
-
-
-FRA_MP_Antagonize = {
-	name = "Antagonize Axis for no Trade"
-	desc = ""
-
-	enable = {
-		original_tag = FRA
-		has_game_rule = {
-			rule = FREE_FRA_ai_behavior
-			option = FREE_FRA_MP_1
-		}
-	}
-
-	abort = {
-	}
-
-	ai_strategy = {
-		type = antagonize
-		id = GER
-		value = 200
-	}
-	ai_strategy = {
-		type = antagonize
-		id = ITA
-		value = 200
-	}	
-	ai_strategy = {
-		type = antagonize
-		id = JAP
-		value = 200
-	}
-	ai_strategy = {
-		type = antagonize
-		id = ROM
-		value = 200
-	}
-	ai_strategy = {
-		type = antagonize
-		id = HUN
-		value = 200
-	}
-}
-
-FRA_MP_Ignore = {
-	name = "Ignore Baltic for Soviet"
-	desc = ""
-
-	enable = {
-		original_tag = FRA
-		has_game_rule = {
-			rule = FREE_FRA_ai_behavior
-			option = FREE_FRA_MP_1
-		}
-	}
-
-	abort = {
-	}
-	
-	ai_strategy = {
-		type = ignore
-		id = LIT
-		value = 200
-	}
-	ai_strategy = {
-		type = ignore
-		id = LAT
-		value = 200
-	}
-	ai_strategy = {
-		type = ignore
-		id = EST
-		value = 200
-	}
-	ai_strategy = {
-		type = ignore
-		id = FIN
-		value = 200
-	}
-}
-
-MP_Spy_Defense = {
-	name = "Spy Defense"
-	desc = ""
-
-	enable = {
-		original_tag = FRA
-		has_game_rule = {
-			rule = FREE_FRA_ai_behavior
-			option = FREE_FRA_MP_1
-		}
-		date < 1938.1.1	
-	}
-
-	abort = {
-		date > 1938.1.1
-	}
-
-	ai_strategy = {
-		type = intelligence_agency_usable_factories
-		value = 5
-	}
-	ai_strategy = {
-		type = intelligence_agency_usable_factories
-		value = 5
-	}
-	ai_strategy = {
-		type = agency_ai_base_num_factories_factor
-		value = -100    # -100% on the define
-	}
-	ai_strategy = {
-		type = agency_ai_per_upgrade_factories_factor
-		value = -100    # -100% on the define
 	}
 }

--- a/common/decisions/FRA.txt
+++ b/common/decisions/FRA.txt
@@ -82,7 +82,7 @@ FRA_vichy_france = {
 		timeout_effect = {
 			transfer_navy = { target = GER }
 			#GER = { annex_country = { target = ROOT } }
-			FRA = { annex_country = { target = ROOT transfer_troops = yes } } 
+			FRA = { annex_country = { target = ROOT transfer_troops = yes } }
 			if = {
 				limit = {
 					NOT = { has_country_flag = scuttled_fleet }
@@ -531,6 +531,19 @@ FRA_spanish_intervention_category = {
 				has_stability < 0.3
 				factor = 5
 			}
+			modifier = {
+				OR = {
+					has_game_rule = {
+						rule = FRA_ai_behavior
+						option = FRA_MP_1
+					}
+					has_game_rule = {
+						rule = FRA_ai_behavior
+						option = FRA_MP_2
+					}
+				}
+				factor = 0
+			}
 		}
 		complete_effect = {
 			FROM = {
@@ -565,6 +578,19 @@ FRA_spanish_intervention_category = {
 				has_stability < 0.3
 				factor = 0
 			}
+			modifier = {
+				OR = {
+					has_game_rule = {
+						rule = FRA_ai_behavior
+						option = FRA_MP_1
+					}
+					has_game_rule = {
+						rule = FRA_ai_behavior
+						option = FRA_MP_2
+					}
+				}
+				factor = 0
+			}
 		}
 		days_remove = -1
 		modifier = {
@@ -588,6 +614,19 @@ FRA_spanish_intervention_category = {
 			modifier = {
 				has_stability < 0.3
 				add = 5
+			}
+			modifier = {
+				OR = {
+					has_game_rule = {
+						rule = FRA_ai_behavior
+						option = FRA_MP_1
+					}
+					has_game_rule = {
+						rule = FRA_ai_behavior
+						option = FRA_MP_2
+					}
+				}
+				factor = 0
 			}
 		}
 	}
@@ -625,6 +664,19 @@ FRA_spanish_intervention_category = {
 				FROM = { has_government = ROOT }
 				factor = 5
 			}
+			modifier = {
+				OR = {
+					has_game_rule = {
+						rule = FRA_ai_behavior
+						option = FRA_MP_1
+					}
+					has_game_rule = {
+						rule = FRA_ai_behavior
+						option = FRA_MP_2
+					}
+				}
+				factor = 0
+			}
 		}
 		cost = 0
 	}
@@ -654,6 +706,19 @@ FRA_spanish_intervention_category = {
 				has_stability < 0.4
 				factor = 0
 			}
+			modifier = {
+				OR = {
+					has_game_rule = {
+						rule = FRA_ai_behavior
+						option = FRA_MP_1
+					}
+					has_game_rule = {
+						rule = FRA_ai_behavior
+						option = FRA_MP_2
+					}
+				}
+				factor = 0
+			}
 		}
 		days_remove = -1
 		modifier = {
@@ -679,6 +744,19 @@ FRA_spanish_intervention_category = {
 			modifier = {
 				has_stability < 0.4
 				add = 5
+			}
+			modifier = {
+				OR = {
+					has_game_rule = {
+						rule = FRA_ai_behavior
+						option = FRA_MP_1
+					}
+					has_game_rule = {
+						rule = FRA_ai_behavior
+						option = FRA_MP_2
+					}
+				}
+				factor = 0
 			}
 		}
 	}
@@ -715,6 +793,19 @@ FRA_spanish_intervention_category = {
 				has_stability < 0.45
 				factor = 0
 			}
+			modifier = {
+				OR = {
+					has_game_rule = {
+						rule = FRA_ai_behavior
+						option = FRA_MP_1
+					}
+					has_game_rule = {
+						rule = FRA_ai_behavior
+						option = FRA_MP_2
+					}
+				}
+				factor = 0
+			}
 		}
 	}
 
@@ -733,6 +824,19 @@ FRA_spanish_intervention_category = {
 			modifier = {
 				has_stability < 0.45
 				add = 5
+			}
+			modifier = {
+				OR = {
+					has_game_rule = {
+						rule = FRA_ai_behavior
+						option = FRA_MP_1
+					}
+					has_game_rule = {
+						rule = FRA_ai_behavior
+						option = FRA_MP_2
+					}
+				}
+				factor = 0
 			}
 		}
 	}
@@ -775,6 +879,19 @@ FRA_spanish_intervention_category = {
 				has_stability < 0.5
 				factor = 0
 			}
+			modifier = {
+				OR = {
+					has_game_rule = {
+						rule = FRA_ai_behavior
+						option = FRA_MP_1
+					}
+					has_game_rule = {
+						rule = FRA_ai_behavior
+						option = FRA_MP_2
+					}
+				}
+				factor = 0
+			}
 		}
 		days_remove = -1
 		modifier = {
@@ -796,6 +913,19 @@ FRA_spanish_intervention_category = {
 			modifier = {
 				has_stability < 0.5
 				add = 5
+			}
+			modifier = {
+				OR = {
+					has_game_rule = {
+						rule = FRA_ai_behavior
+						option = FRA_MP_1
+					}
+					has_game_rule = {
+						rule = FRA_ai_behavior
+						option = FRA_MP_2
+					}
+				}
+				factor = 0
 			}
 		}
 		cost = 0
@@ -827,6 +957,16 @@ FRA_spanish_intervention_category = {
 			}
 			modifier = {
 				has_stability < 0.8
+				NOT = {
+					has_game_rule = {
+						rule = FRA_ai_behavior
+						option = FRA_MP_1
+					}
+					has_game_rule = {
+						rule = FRA_ai_behavior
+						option = FRA_MP_2
+					}
+				}
 				factor = 0.5
 			}
 		}
@@ -864,6 +1004,20 @@ FRA_spanish_intervention_category = {
 				has_stability < 0.55
 				add = 5
 			}
+			modifier = {
+				OR = {
+					has_game_rule = {
+						rule = FRA_ai_behavior
+						option = FRA_MP_1
+					}
+					has_game_rule = {
+						rule = FRA_ai_behavior
+						option = FRA_MP_2
+					}
+				}
+				factor = 0
+			}
+
 		}
 	}
 
@@ -995,6 +1149,19 @@ FRA_spanish_intervention_category = {
 			}
 			modifier = {
 				is_historical_focus_on = yes
+				factor = 0
+			}
+			modifier = {
+				OR = {
+					has_game_rule = {
+						rule = FRA_ai_behavior
+						option = FRA_MP_1
+					}
+					has_game_rule = {
+						rule = FRA_ai_behavior
+						option = FRA_MP_2
+					}
+				}
 				factor = 0
 			}
 		}
@@ -1539,6 +1706,13 @@ FRA_intervention_in_overseas_territories = {
 		cost = 25
 		ai_will_do = {
 			factor = 3
+			modifier = {
+				has_game_rule = {
+					rule = FREE_FRA_ai_behavior
+					option = FREE_FRA_MP_1
+				}
+				factor = 0
+			}
 		}
 	}
 	FRA_prepare_coup_in_north_africa = {
@@ -1563,6 +1737,13 @@ FRA_intervention_in_overseas_territories = {
 		cost = 25
 		ai_will_do = {
 			factor = 0 #at least until we know the AI can handle it
+			modifier = {
+				has_game_rule = {
+					rule = FREE_FRA_ai_behavior
+					option = FREE_FRA_MP_1
+				}
+				add = 100
+			}
 		}
 	}
 	FRA_promise_independence_to_syria = {
@@ -1608,6 +1789,13 @@ FRA_intervention_in_overseas_territories = {
 		cost = 25
 		ai_will_do = {
 			factor = 3
+			modifier = {
+				has_game_rule = {
+					rule = FREE_FRA_ai_behavior
+					option = FREE_FRA_MP_1
+				}
+				factor = 0
+			}
 		}
 		
 	}
@@ -1665,9 +1853,21 @@ FRA_intervention_in_overseas_territories = {
 			} 
 		} 
 
-		visible = { has_completed_focus = FRA_intervention_in_syria }
+		visible = {
+			NOT = { has_global_flag = Invasion_in_Syria }
+			FRA = { has_completed_focus = FRA_intervention_in_syria }
+			OR = {
+				AND = {
+					tag = FRA
+					NOT = { has_focus_tree = vichy_french_focus }
+					NOT = { is_subject_of = GER }
+				}
+				tag = ENG
+			}
+		}
 
-		complete_effect = { 
+		complete_effect = {
+			set_global_flag = Invasion_in_Syria
 			random_state = { #find a neighbouring state of Syria that is controlled by an ally or ourselves
 				limit = {
 					OR = {
@@ -1834,6 +2034,13 @@ FRA_intervention_in_overseas_territories = {
 		cost = 25
 		ai_will_do = {
 			factor = 3
+			modifier = {
+				has_game_rule = {
+					rule = FREE_FRA_ai_behavior
+					option = FREE_FRA_MP_1
+				}
+				factor = 0
+			}
 		}
 	}
 	FRA_prepare_coup_in_indochina = {
@@ -1856,6 +2063,13 @@ FRA_intervention_in_overseas_territories = {
 		cost = 25
 		ai_will_do = {
 			factor = 0
+			modifier = {
+				has_game_rule = {
+					rule = FREE_FRA_ai_behavior
+					option = FREE_FRA_MP_1
+				}
+				factor = 0
+			}
 		}
 	}
 	FRA_invasion_in_indochina = {
@@ -2013,6 +2227,13 @@ FRA_intervention_in_overseas_territories = {
 		fire_only_once = yes
 		ai_will_do = {
 			factor = 0
+			modifier = {
+				has_game_rule = {
+					rule = FREE_FRA_ai_behavior
+					option = FREE_FRA_MP_1
+				}
+				factor = 0
+			}
 		}
 		cost = 25
 	}
@@ -2055,6 +2276,13 @@ FRA_intervention_in_overseas_territories = {
 		cost = 25
 		ai_will_do = {
 			factor = 3
+			modifier = {
+				has_game_rule = {
+					rule = FREE_FRA_ai_behavior
+					option = FREE_FRA_MP_1
+				}
+				factor = 0
+			}
 		}
 		
 	}
@@ -2107,9 +2335,21 @@ FRA_intervention_in_overseas_territories = {
 			} 
 		} 
 
-		visible = { has_completed_focus = FRA_intervention_in_central_africa }
+		visible = {
+			NOT = { has_global_flag = Invasion_in_Central_Africa }
+			FRA = { has_completed_focus = FRA_intervention_in_central_africa }
+			OR = {
+				AND = {
+					tag = FRA
+					NOT = { has_focus_tree = vichy_french_focus }
+					NOT = { is_subject_of = GER }
+				}
+				tag = ENG
+			}
+		}
 
-		complete_effect = { 
+		complete_effect = {
+			set_global_flag = Invasion_in_Central_Africa
 			random_state = { #find a neighbouring state of Syria that is controlled by an ally or ourselves
 				limit = {
 					OR = {
@@ -2244,6 +2484,13 @@ FRA_intervention_in_overseas_territories = {
 		cost = 25
 		ai_will_do = {
 			factor = 0
+			modifier = {
+				has_game_rule = {
+					rule = FREE_FRA_ai_behavior
+					option = FREE_FRA_MP_1
+				}
+				add = 100
+			}
 		}
 	}
 	FRA_promise_independence_to_west_africa = {
@@ -2288,6 +2535,13 @@ FRA_intervention_in_overseas_territories = {
 		cost = 25
 		ai_will_do = {
 			factor = 3
+			modifier = {
+				has_game_rule = {
+					rule = FREE_FRA_ai_behavior
+					option = FREE_FRA_MP_1
+				}
+				factor = 0
+			}
 		}
 	}
 	FRA_prepare_coup_in_west_africa = {
@@ -2343,9 +2597,21 @@ FRA_intervention_in_overseas_territories = {
 			} 
 		} 
 
-		visible = { has_completed_focus = FRA_intervention_in_west_africa }
+		visible = {
+			NOT = { has_global_flag = Invasion_in_West_Africa }
+			FRA = { has_completed_focus = FRA_intervention_in_west_africa }
+			OR = {
+				AND = {
+					tag = FRA
+					NOT = { has_focus_tree = vichy_french_focus }
+					NOT = { is_subject_of = GER }
+				}
+				tag = ENG
+			}
+		}
 
 		complete_effect = { 
+			set_global_flag = Invasion_in_West_Africa
 			random_state = { #find a neighbouring state of Syria that is controlled by an ally or ourselves
 				limit = {
 					OR = {
@@ -2482,6 +2748,13 @@ FRA_intervention_in_overseas_territories = {
 		cost = 25
 		ai_will_do = {
 			factor = 0
+			modifier = {
+				has_game_rule = {
+					rule = FREE_FRA_ai_behavior
+					option = FREE_FRA_MP_1
+				}
+				add = 100
+			}
 		}
 	}
 

--- a/common/decisions/categories/FRA_decision_categories.txt
+++ b/common/decisions/categories/FRA_decision_categories.txt
@@ -36,7 +36,7 @@ FRA_intervention_in_overseas_territories = {
 		OR = {
 			AND = {
 				tag = FRA
-				NOT = { has_focus_tree = vichy_french_focus }
+				NOT = { has_government = fascism }
 				NOT = { is_subject_of = GER }
 			}
 			tag = ENG
@@ -47,7 +47,7 @@ FRA_intervention_in_overseas_territories = {
 		OR = {
 			AND = {
 				tag = FRA
-				NOT = { has_focus_tree = vichy_french_focus }
+				NOT = { has_government = fascism }
 				NOT = { is_subject_of = GER }
 			}
 			tag = ENG

--- a/common/decisions/categories/FRA_decision_categories.txt
+++ b/common/decisions/categories/FRA_decision_categories.txt
@@ -1,0 +1,72 @@
+################
+##### FRA ######
+################
+
+FRA_vichy_france = {
+	
+	allowed = {
+		original_tag = FRA
+	}
+}
+
+FRA_spanish_intervention_category = {
+	allowed = {
+		original_tag = FRA
+	}
+	visible = {
+		has_completed_focus = FRA_intervention_in_spain
+		SPR_scw_in_progress = yes
+	}
+}
+
+VIC_concessions_to_the_germans = {
+	allowed = {
+		original_tag = FRA
+	}
+	visible = {
+		OR = {
+			has_completed_focus = VIC_concessions_to_the_germans
+			controls_state = 16
+		}
+	}
+}
+
+FRA_intervention_in_overseas_territories = {
+	allowed = {
+		OR = {
+			AND = {
+				tag = FRA
+				NOT = { has_focus_tree = vichy_french_focus }
+				NOT = { is_subject_of = GER }
+			}
+			tag = ENG
+		}
+	}
+	visible = {
+		FRA = { has_completed_focus = FRA_intervention_in_syria }
+		OR = {
+			AND = {
+				tag = FRA
+				NOT = { has_focus_tree = vichy_french_focus }
+				NOT = { is_subject_of = GER }
+			}
+			tag = ENG
+		}
+	}
+}
+
+FRA_weapons_purchases_category = {
+	allowed = {
+		original_tag = FRA
+	}
+	visible = {
+		has_country_flag = FRA_arms_purchases_permitted
+		NOT = {
+			has_war_with = USA
+		}
+	}
+}
+
+FRA_decolonization = {
+	allowed = { original_tag = FRA }
+}

--- a/events/LaR_France.txt
+++ b/events/LaR_France.txt
@@ -1,0 +1,4471 @@
+﻿#La Resistance France events
+
+ ##   ##  #  #  ##  ###  ###  ##  ##      ##  ###     ###   ##  ###  ###  ## 
+#  # #  # ## # #    #  # #   #   #       #  # #       #  # #  # #  #  #  #   
+#    #  # # ## # ## ###  ##   #   #      #  # ##      ###  #### ###   #   #  
+#  # #  # #  # #  # #  # #     #   #     #  # #       #    #  # #  #  #    # 
+ ##   ##  #  #  ##  #  # ### ##  ##       ##  #       #    #  # #  # ### ##  
+
+
+add_namespace = lar_congress_of_paris
+
+#opening event for France - set up claims, pass on to Italy
+country_event = {
+	id = lar_congress_of_paris.1
+	title = lar_congress_of_paris.1.t
+	desc = lar_congress_of_paris.1.desc
+	picture = GFX_report_event_fascist_gathering
+	is_triggered_only = yes
+
+	option = {
+		name = lar_congress_of_paris.1.a
+		add_state_claim = 558
+		add_state_claim = 274
+		add_state_claim = 700
+		add_state_claim = 701
+		add_state_claim = 538
+		add_state_claim = 718
+		add_state_claim = 768
+		add_state_claim = 769
+		if = {
+			limit = { is_in_faction_with = ITA }
+			ITA = {
+				country_event = lar_congress_of_paris.2
+			}
+		}
+		else_if = { #failsafes in case one of these countries not in faction
+			limit = {
+				is_in_faction_with = SPA
+			}
+			SPA = { country_event = lar_congress_of_paris.5 }
+		}
+		else_if = {
+			limit = {
+				is_in_faction_with = POR
+			}
+			POR = {
+				country_event = lar_congress_of_paris.6
+			}
+		}
+		else = {
+			hidden_effect = {
+				news_event = { id = lar_news.3 days = 3 random_days = 5 }
+			}
+		}
+	}
+}
+
+#second event for Italy
+country_event = {
+	id = lar_congress_of_paris.2
+	title = lar_congress_of_paris.2.t
+	desc = lar_congress_of_paris.2.desc
+	picture = GFX_report_event_fascist_gathering
+	is_triggered_only = yes
+
+	option = {
+		name = lar_congress_of_paris.2.a #agree, set up claims, pass on to Spain
+		ai_chance = {
+			base = 100
+		}
+		FRA_congress_of_paris_italian_claims_setup_effect = yes
+		FRA = {
+			country_event = lar_congress_of_paris.3
+		}
+		if = {
+			limit = { is_in_faction_with = SPA }
+			SPA = {
+				country_event = lar_congress_of_paris.5
+			}
+		}
+		else_if = {
+			limit = {
+				is_in_faction_with = POR
+			}
+			POR = {
+				country_event = lar_congress_of_paris.6
+			}
+		}
+		else = {
+			hidden_effect = {
+				news_event = { id = lar_news.3 days = 3 random_days = 5 }
+			}
+		}
+	}
+
+	option = {
+		name = lar_congress_of_paris.2.b #refuse, claims go to France instead, pass on to Spain
+		ai_chance = {
+			base = 0
+		}
+		FRA= { 
+			country_event = lar_congress_of_paris.4
+			FRA_congress_of_paris_italian_claims_setup_effect = yes 
+			effect_tooltip = {
+				remove_from_faction = PREV
+			}
+		}
+		if = {
+			limit = { is_in_faction_with = SPA }
+			SPA = {
+				country_event = lar_congress_of_paris.5
+			}
+		}
+		else_if = {
+			limit = {
+				is_in_faction_with = POR
+			}
+			POR = {
+				country_event = lar_congress_of_paris.6
+			}
+		}
+		else = {
+			hidden_effect = {
+				news_event = { id = lar_news.3 days = 3 random_days = 5 }
+			}
+		}
+	}
+}
+#generic event - country agrees
+country_event = {
+	id = lar_congress_of_paris.3
+	title = lar_congress_of_paris.3.t
+	desc = lar_congress_of_paris.3.desc
+	picture = GFX_report_event_generic_conference
+	is_triggered_only = yes
+
+	option = {
+		name = lar_congress_of_paris.3.a #cool
+		
+	}
+}
+#generic event - country refuses
+country_event = {
+	id = lar_congress_of_paris.4
+	title = lar_congress_of_paris.4.t
+	desc = lar_congress_of_paris.4.desc
+	picture = GFX_report_event_german_politician_speech
+	is_triggered_only = yes
+
+	option = {
+		name = lar_congress_of_paris.4.a #remove from faction
+		remove_from_faction = FROM
+	}
+}
+
+#third event for Spain
+country_event = {
+	id = lar_congress_of_paris.5
+	title = lar_congress_of_paris.2.t
+	desc = lar_congress_of_paris.5.desc
+	picture = GFX_report_event_fascist_gathering
+	is_triggered_only = yes
+
+	option = {
+		name = lar_congress_of_paris.5.a #agree, transfer territories, pass on to Portugal
+		ai_chance = {
+			base = 100
+		}
+		FRA = {
+			country_event = lar_congress_of_paris.3
+		}
+		transfer_state = 461
+		transfer_state = 462
+		if = {
+			limit = { is_in_faction_with = POR }
+			POR = {
+				country_event = lar_congress_of_paris.6
+			}
+		}
+		else = {
+			hidden_effect = {
+				news_event = { id = lar_news.3 days = 3 random_days = 5 }
+			}
+		}
+	}
+
+	option = {
+		name = lar_congress_of_paris.5.b #refuse, pass on to Portugal
+		ai_chance = {
+			base = 0
+		}
+		FRA= { 
+			country_event = lar_congress_of_paris.4 
+			effect_tooltip = {
+				remove_from_faction = PREV
+			}
+		}
+		if = {
+			limit = { is_in_faction_with = POR }
+			POR = {
+				country_event = lar_congress_of_paris.6
+			}
+		}
+		else = {
+			hidden_effect = {
+				news_event = { id = lar_news.3 days = 3 random_days = 5 }
+			}
+		}
+	}
+}
+
+#fourth event for Portugal
+country_event = {
+	id = lar_congress_of_paris.6
+	title = lar_congress_of_paris.2.t
+	desc = lar_congress_of_paris.6.desc
+	picture = GFX_report_event_fascist_gathering
+	is_triggered_only = yes
+
+	option = {
+		name = lar_congress_of_paris.6.a #agree, set up claims
+		ai_chance = {
+			base = 100
+		}
+		FRA_congress_of_paris_portugese_claims_setup_effect = yes
+		FRA = {
+			country_event = lar_congress_of_paris.3
+		}
+
+		hidden_effect = {
+			news_event = { id = lar_news.3 days = 3 random_days = 5 }
+		}
+		
+	}
+
+	option = {
+		name = lar_congress_of_paris.6.b #refuse, claims go to France instead
+		ai_chance = {
+			base = 0
+		}
+		FRA= { 
+			country_event = lar_congress_of_paris.4
+			FRA_congress_of_paris_portugese_claims_setup_effect = yes 
+			effect_tooltip = {
+				remove_from_faction = PREV
+			}
+		}
+		hidden_effect = {
+			news_event = { id = lar_news.3 days = 3 random_days = 5 }
+		}
+	}
+}
+
+###   ##  #   ### ### ###  ##   ##  #       #   # ###  ##  #   ### #  #  ##  ### 
+#  # #  # #    #   #   #  #  # #  # #       #   #  #  #  # #   #   ## # #  # #   
+###  #  # #    #   #   #  #    #### #        # #   #  #  # #   ##  # ## #    ##  
+#    #  # #    #   #   #  #  # #  # #        # #   #  #  # #   #   #  # #  # #   
+#     ##  ### ###  #  ###  ##  #  # ###       #   ###  ##  ### ### #  #  ##  ### 
+
+
+add_namespace = lar_france_political_violence
+
+# right wing riots
+country_event = {
+	id = lar_france_political_violence.1
+	title = lar_france_political_violence.1.t
+	desc = lar_france_political_violence.1.desc
+	picture = GFX_report_event_generic_riot
+	is_triggered_only = yes
+
+	option = {
+		name = lar_france_political_violence.1.a #ignore
+		add_stability = -0.05
+		add_popularity = { ideology = fascism popularity = 0.025 }
+		add_popularity = { ideology = neutrality popularity = 0.025 }
+	}
+
+	option = {
+		name = lar_france_political_violence.1.b #prosecute
+		add_political_power = -50
+	}
+}
+
+# communist riots
+country_event = {
+	id = lar_france_political_violence.2
+	title = lar_france_political_violence.1.t
+	desc = lar_france_political_violence.2.desc
+	picture = GFX_report_event_generic_riot
+	is_triggered_only = yes
+
+	option = {
+		name = lar_france_political_violence.1.a #ignore
+		add_stability = -0.05
+		add_popularity = { ideology = communism popularity = 0.025 }
+	}
+
+	option = {
+		name = lar_france_political_violence.1.b #prosecute
+		add_political_power = -50
+	}
+}
+
+# massive right wing riots
+country_event = {
+	id = lar_france_political_violence.3
+	title = lar_france_political_violence.3.t
+	desc = lar_france_political_violence.3.desc
+	picture = GFX_report_event_generic_riot
+	is_triggered_only = yes
+
+	option = {
+		name = lar_france_political_violence.3.a #ignore
+		add_stability = -0.1
+		add_popularity = { ideology = fascism popularity = 0.05 }
+		add_popularity = { ideology = neutrality popularity = 0.05 }
+	}
+
+	option = {
+		name = lar_france_political_violence.3.b #prosecute
+		add_political_power = -150
+	}
+}
+
+# political violence returns at low stability
+country_event = {
+	id = lar_france_political_violence.4
+	title = lar_france_political_violence.4.t
+	desc = lar_france_political_violence.4.desc
+	picture = GFX_report_event_generic_rally2
+	mean_time_to_happen = { days = 50 }
+
+	trigger = {
+		original_tag = FRA
+		NOT = {
+			has_completed_focus = FRA_ban_communism
+			has_completed_focus = FRA_ban_the_leagues
+		}
+		not = { has_idea = FRA_political_violence }
+		has_stability < 0.5
+		has_capitulated = no
+	}
+
+	immediate = {
+		hidden_effect = {
+			add_ideas = FRA_political_violence
+		}
+	}
+
+	option = {
+		name = lar_france_political_violence.4.a #ignore
+		effect_tooltip = {
+			add_ideas = FRA_political_violence
+		}
+	}
+}
+
+### ###  ### #  #  ##  #  #     #  # #  # ###  ##  #  # 
+#   #  # #   ## # #  # #  #     #  # ## #  #  #  # ## # 
+##  ###  ##  # ## #    ####     #  # # ##  #  #  # # ## 
+#   #  # #   #  # #  # #  #     #  # #  #  #  #  # #  # 
+#   #  # ### #  #  ##  #  #      ##  #  # ###  ##  #  # 
+
+
+add_namespace = lar_france_french_union
+
+country_event = {
+	id = lar_france_french_union.1
+
+	is_triggered_only = yes
+	hidden = yes
+
+	immediate = {
+		if = {
+			limit = {
+				FRA_controls_north_africa = yes
+			}
+			random_list = {#north africa
+				25 = {
+					modifier = {
+						has_country_flag = FRA_north_africa_promised_independence
+						factor = 0.25
+					}
+					country_event = lar_france_french_union.2 #accepts
+				} 
+				75 = { country_event = lar_france_french_union.3 } #refuses
+			}
+		}
+		if = {
+			limit = {
+				FRA_controls_west_africa = yes
+			}
+			random_list = {#west africa
+				45 = {
+					modifier = {
+						has_country_flag = FRA_west_africa_promised_independence
+						factor = 0.25
+					}
+					country_event = lar_france_french_union.4 #accepts
+				} 
+				55 = { country_event = lar_france_french_union.5 } #refuses
+			}
+		}
+		if = {
+			limit = {
+				FRA_controls_central_africa = yes
+			}
+			random_list = {#central africa
+				45 = {
+					modifier = {
+						has_country_flag = FRA_central_africa_promised_independence
+						factor = 0.25
+					}
+					country_event = lar_france_french_union.6 #accepts
+				} 
+				55 = { country_event = lar_france_french_union.7 } #refuses
+			}
+		}
+		if = {
+			limit = {
+				FRA_controls_syria = yes
+			}
+			random_list = {#syria
+				15 = {
+					modifier = {
+						has_country_flag = FRA_syria_promised_independence
+						factor = 0.25
+					}
+					country_event = lar_france_french_union.8 #accepts
+				} 
+				85 = { country_event = lar_france_french_union.9 } #refuses
+			}
+		}
+		if = {
+			limit = {
+				FRA_controls_indochina = yes
+			}
+			random_list = {#indochina
+				5 = {
+					modifier = {
+						has_country_flag = FRA_indochina_promised_independence
+						factor = 0.25
+					}
+					country_event = lar_france_french_union.10 #accepts
+				} 
+				95 = { country_event = lar_france_french_union.11 } #refuses
+			}
+		}
+	}
+
+	option = {
+		name = lar_france_french_union.1.a 
+		
+	}
+}
+#north africa agrees
+country_event = {
+	id = lar_france_french_union.2
+	title = lar_france_french_union.2.t
+	desc = lar_france_french_union.2.desc
+	picture = GFX_report_event_election_vote #todo candidate for uniques
+	is_triggered_only = yes
+	option = {
+		name = lar_france_french_union.2.a
+		if = {
+			limit = {
+				ALG = {
+					exists = yes
+					is_subject_of = ROOT
+				}
+			}
+			annex_country = { target = ALG }
+		}
+		if = {
+			limit = {
+				TUN = {
+					exists = yes
+					is_subject_of = ROOT
+				}
+			}
+			annex_country = { target = TUN }
+		}
+		if = {
+			limit = {
+				MOR = {
+					exists = yes
+					is_subject_of = ROOT
+				}
+			}
+			annex_country = { target = MOR }
+		}
+		every_owned_state = {
+			limit = {
+				OR = {
+					is_core_of = ALG
+					is_core_of = TUN
+					is_core_of = MOR
+				}
+			}
+			add_core_of = ROOT
+		}
+	}
+}
+
+#north africa refuses
+country_event = {
+	id = lar_france_french_union.3
+	title = lar_france_french_union.3.t
+	desc = lar_france_french_union.3.desc
+	picture = GFX_report_event_ghandi_women #TODO candidate for unique
+	is_triggered_only = yes
+	option = {
+		name = lar_france_french_union.3.a
+		if = {
+			limit = {
+				ALG = {
+					exists = yes
+					is_subject_of = ROOT
+				}
+			}
+			OVERLORD = {
+				set_autonomy = {
+					target = ALG
+					autonomy_state = autonomy_free
+				}
+			}
+		}
+		if = {
+			limit = {
+				TUN = {
+					exists = yes
+					is_subject_of = ROOT
+				}
+			}
+			OVERLORD = {
+				set_autonomy = {
+					target = TUN
+					autonomy_state = autonomy_free
+				}
+			}
+		}
+		if = {
+			limit = {
+				MOR = {
+					exists = yes
+					is_subject_of = ROOT
+				}
+			}
+			OVERLORD = {
+				set_autonomy = {
+					target = MOR
+					autonomy_state = autonomy_free
+				}
+			}
+		}
+		every_owned_state = {
+			limit = {
+				is_controlled_by = ROOT
+				NOT = { is_core_of = ROOT }
+				OR = {
+					is_core_of = ALG
+					is_core_of = TUN
+					is_core_of = MOR
+				}
+			}
+			add_resistance_target = {
+				amount = 55
+				tooltip = LAR_fra_voted_independence_tt
+			}
+		}
+	}
+}
+
+#west africa agrees
+country_event = {
+	id = lar_france_french_union.4
+	title = lar_france_french_union.4.t
+	desc = lar_france_french_union.4.desc
+	picture = GFX_report_event_election_vote
+	is_triggered_only = yes
+	option = {
+		name = lar_france_french_union.2.a
+		if = {
+			limit = {
+				SEN = {
+					exists = yes
+					is_subject_of = ROOT
+				}
+			}
+			annex_country = { target = SEN }
+		}
+		if = {
+			limit = {
+				MRT = {
+					exists = yes
+					is_subject_of = ROOT
+				}
+			}
+			annex_country = { target = MRT }
+		}
+		if = {
+			limit = {
+				GNA = {
+					exists = yes
+					is_subject_of = ROOT
+				}
+			}
+			annex_country = { target = GNA }
+		}
+		if = {
+			limit = {
+				MLI = {
+					exists = yes
+					is_subject_of = ROOT
+				}
+			}
+			annex_country = { target = MLI }
+		}
+		if = {
+			limit = {
+				IVO = {
+					exists = yes
+					is_subject_of = ROOT
+				}
+			}
+			annex_country = { target = IVO }
+		}
+		if = {
+			limit = {
+				VOL = {
+					exists = yes
+					is_subject_of = ROOT
+				}
+			}
+			annex_country = { target = VOL }
+		}
+		if = {
+			limit = {
+				NGR = {
+					exists = yes
+					is_subject_of = ROOT
+				}
+			}
+			annex_country = { target = NGR }
+		}
+		if = {
+			limit = {
+				DAH = {
+					exists = yes
+					is_subject_of = ROOT
+				}
+			}
+			annex_country = { target = DAH }
+		}
+		if = {
+			limit = {
+				TOG = {
+					exists = yes
+					is_subject_of = ROOT
+				}
+			}
+			annex_country = { target = TOG }
+		}
+		every_owned_state = {
+			limit = {
+				OR = {
+					is_core_of = SEN
+					is_core_of = MRT
+					is_core_of = GNA
+					is_core_of = MLI
+					is_core_of = IVO
+					is_core_of = VOL
+					is_core_of = NGR
+					is_core_of = DAH
+					is_core_of = TOG
+				}
+			}
+			add_core_of = ROOT
+		}
+	}
+}
+
+#west africa refuses
+country_event = {
+	id = lar_france_french_union.5
+	title = lar_france_french_union.5.t
+	desc = lar_france_french_union.5.desc
+	picture = GFX_report_event_ghandi_women
+	is_triggered_only = yes
+	option = {
+		name = lar_france_french_union.3.a
+		if = {
+			limit = {
+				SEN = {
+					exists = yes
+					is_subject_of = ROOT
+				}
+			}
+			OVERLORD = {
+				set_autonomy = {
+					target = SEN
+					autonomy_state = autonomy_free
+				}
+			}
+		}
+		if = {
+			limit = {
+				MRT = {
+					exists = yes
+					is_subject_of = ROOT
+				}
+			}
+			OVERLORD = {
+				set_autonomy = {
+					target = MRT
+					autonomy_state = autonomy_free
+				}
+			}
+		}
+		if = {
+			limit = {
+				GNA = {
+					exists = yes
+					is_subject_of = ROOT
+				}
+			}
+			OVERLORD = {
+				set_autonomy = {
+					target = GNA
+					autonomy_state = autonomy_free
+				}
+			}
+		}
+		if = {
+			limit = {
+				MLI = {
+					exists = yes
+					is_subject_of = ROOT
+				}
+			}
+			OVERLORD = {
+				set_autonomy = {
+					target = MLI
+					autonomy_state = autonomy_free
+				}
+			}
+		}
+		if = {
+			limit = {
+				IVO = {
+					exists = yes
+					is_subject_of = ROOT
+				}
+			}
+			OVERLORD = {
+				set_autonomy = {
+					target = IVO
+					autonomy_state = autonomy_free
+				}
+			}
+		}
+		if = {
+			limit = {
+				VOL = {
+					exists = yes
+					is_subject_of = ROOT
+				}
+			}
+			OVERLORD = {
+				set_autonomy = {
+					target = VOL
+					autonomy_state = autonomy_free
+				}
+			}
+		}
+		if = {
+			limit = {
+				NGR = {
+					exists = yes
+					is_subject_of = ROOT
+				}
+			}
+			OVERLORD = {
+				set_autonomy = {
+					target = NGR
+					autonomy_state = autonomy_free
+				}
+			}
+		}
+		if = {
+			limit = {
+				DAH = {
+					exists = yes
+					is_subject_of = ROOT
+				}
+			}
+			OVERLORD = {
+				set_autonomy = {
+					target = DAH
+					autonomy_state = autonomy_free
+				}
+			}
+		}
+		if = {
+			limit = {
+				TOG = {
+					exists = yes
+					is_subject_of = ROOT
+				}
+			}
+			OVERLORD = {
+				set_autonomy = {
+					target = TOG
+					autonomy_state = autonomy_free
+				}
+			}
+		}
+		every_owned_state = {
+			limit = {
+				OR = {
+					is_core_of = TOG
+					is_core_of = DAH
+					is_core_of = NGR
+					is_core_of = IVO
+					is_core_of = VOL
+					is_core_of = SEN
+					is_core_of = MLI
+					is_core_of = GNA
+					is_core_of = MRT
+				}
+			}
+			add_resistance_target = {
+				amount = 55
+				tooltip = LAR_fra_voted_independence_tt
+			}
+		}
+	}
+}
+
+#central africa agrees
+country_event = {
+	id = lar_france_french_union.6
+	title = lar_france_french_union.6.t
+	desc = lar_france_french_union.6.desc
+	picture = GFX_report_event_election_vote
+	is_triggered_only = yes
+	option = {
+		name = lar_france_french_union.2.a
+		if = {
+			limit = {
+				CHA = {
+					exists = yes
+					is_subject_of = ROOT
+				}
+			}
+			annex_country = { target = CHA }
+		}
+		if = {
+			limit = {
+				CMR = {
+					exists = yes
+					is_subject_of = ROOT
+				}
+			}
+			annex_country = { target = CMR }
+		}
+		if = {
+			limit = {
+				CAR = {
+					exists = yes
+					is_subject_of = ROOT
+				}
+			}
+			annex_country = { target = CAR }
+		}
+		if = {
+			limit = {
+				RCG = {
+					exists = yes
+					is_subject_of = ROOT
+				}
+			}
+			annex_country = { target = RCG }
+		}
+		if = {
+			limit = {
+				GAB = {
+					exists = yes
+					is_subject_of = ROOT
+				}
+			}
+			annex_country = { target = GAB }
+		}
+		every_owned_state = {
+			limit = {
+				OR = {
+					is_core_of = CHA
+					is_core_of = CMR
+					is_core_of = CAR
+					is_core_of = RCG
+					is_core_of = GAB
+				}
+			}
+			add_core_of = ROOT
+		}
+	}
+}
+
+#central africa refuses
+country_event = {
+	id = lar_france_french_union.7
+	title = lar_france_french_union.7.t
+	desc = lar_france_french_union.7.desc
+	picture = GFX_report_event_ghandi_women
+	is_triggered_only = yes
+	option = {
+		name = lar_france_french_union.3.a
+		if = {
+			limit = {
+				CHA = {
+					exists = yes
+					is_subject_of = ROOT
+				}
+			}
+			OVERLORD = {
+				set_autonomy = {
+					target = CHA
+					autonomy_state = autonomy_free
+				}
+			}
+		}
+		if = {
+			limit = {
+				CMR = {
+					exists = yes
+					is_subject_of = ROOT
+				}
+			}
+			OVERLORD = {
+				set_autonomy = {
+					target = CMR
+					autonomy_state = autonomy_free
+				}
+			}
+		}
+		if = {
+			limit = {
+				CAR = {
+					exists = yes
+					is_subject_of = ROOT
+				}
+			}
+			OVERLORD = {
+				set_autonomy = {
+					target = CAR
+					autonomy_state = autonomy_free
+				}
+			}
+		}
+		if = {
+			limit = {
+				RCG = {
+					exists = yes
+					is_subject_of = ROOT
+				}
+			}
+			OVERLORD = {
+				set_autonomy = {
+					target = RCG
+					autonomy_state = autonomy_free
+				}
+			}
+		}
+		if = {
+			limit = {
+				GAB = {
+					exists = yes
+					is_subject_of = ROOT
+				}
+			}
+			OVERLORD = {
+				set_autonomy = {
+					target = GAB
+					autonomy_state = autonomy_free
+				}
+			}
+		}
+		every_owned_state = {
+			limit = {
+				is_controlled_by = ROOT
+				OR = {
+					is_core_of = CHA
+					is_core_of = CMR
+					is_core_of = CAR
+					is_core_of = RCG
+					is_core_of = GAB
+				}
+			}
+			add_resistance_target = {
+				amount = 55
+				tooltip = LAR_fra_voted_independence_tt
+			}
+		}
+	}
+}
+
+#Syria agrees
+country_event = {
+	id = lar_france_french_union.8
+	title = lar_france_french_union.8.t
+	desc = lar_france_french_union.8.desc
+	picture = GFX_report_event_election_vote
+	is_triggered_only = yes
+	option = {
+		name = lar_france_french_union.2.a
+		if = {
+			limit = {
+				SYR = {
+					exists = yes
+					is_subject_of = ROOT
+				}
+			}
+			annex_country = { target = SYR }
+		}
+		if = {
+			limit = {
+				LEB = {
+					exists = yes
+					is_subject_of = ROOT
+				}
+			}
+			annex_country = { target = LEB }
+		}
+		every_owned_state = {
+			limit = {
+				OR = {
+					is_core_of = SYR
+					is_core_of = LEB
+				}
+			}
+			add_core_of = ROOT
+		}
+	}
+}
+
+#Syria refuses
+country_event = {
+	id = lar_france_french_union.9
+	title = lar_france_french_union.9.t
+	desc = lar_france_french_union.9.desc
+	picture = GFX_report_event_ghandi_women
+	is_triggered_only = yes
+	option = {
+		name = lar_france_french_union.3.a
+		if = {
+			limit = {
+				SYR = {
+					exists = yes
+					is_subject_of = ROOT
+				}
+			}
+			OVERLORD = {
+				set_autonomy = {
+					target = SYR
+					autonomy_state = autonomy_free
+				}
+			}
+		}
+		if = {
+			limit = {
+				LEB = {
+					exists = yes
+					is_subject_of = ROOT
+				}
+			}
+			OVERLORD = {
+				set_autonomy = {
+					target = LEB
+					autonomy_state = autonomy_free
+				}
+			}
+		}
+		every_owned_state = {
+			limit = {
+				is_controlled_by = ROOT
+				OR = {
+					is_core_of = LEB
+					is_core_of = SYR
+				}
+			}
+			add_resistance_target = {
+				amount = 55
+				tooltip = LAR_fra_voted_independence_tt
+			}
+		}
+	}
+}
+#Indochina agrees
+country_event = {
+	id = lar_france_french_union.10
+	title = lar_france_french_union.10.t
+	desc = lar_france_french_union.10.desc
+	picture = GFX_report_event_election_vote
+	is_triggered_only = yes
+	option = {
+		name = lar_france_french_union.2.a
+		if = {
+			limit = {
+				VIN = {
+					exists = yes
+					is_subject_of = ROOT
+				}
+			}
+			annex_country = { target = VIN }
+		}
+		if = {
+			limit = {
+				LAO = {
+					exists = yes
+					is_subject_of = ROOT
+				}
+			}
+			annex_country = { target = LAO }
+		}
+		if = {
+			limit = {
+				CAM = {
+					exists = yes
+					is_subject_of = ROOT
+				}
+			}
+			annex_country = { target = CAM }
+		}
+		every_owned_state = {
+			limit = {
+				OR = {
+					is_core_of = VIN
+					is_core_of = LAO
+					is_core_of = CAM
+				}
+			}
+			add_core_of = ROOT
+		}
+	}
+}
+
+#Indochina refuses
+country_event = {
+	id = lar_france_french_union.11
+	title = lar_france_french_union.11.t
+	desc = lar_france_french_union.11.desc
+	picture = GFX_report_event_ghandi_women
+	is_triggered_only = yes
+	option = {
+		name = lar_france_french_union.3.a
+		if = {
+			limit = {
+				VIN = {
+					exists = yes
+					is_subject_of = ROOT
+				}
+			}
+			OVERLORD = {
+				set_autonomy = {
+					target = VIN
+					autonomy_state = autonomy_free
+				}
+			}
+		}
+		if = {
+			limit = {
+				LAO = {
+					exists = yes
+					is_subject_of = ROOT
+				}
+			}
+			OVERLORD = {
+				set_autonomy = {
+					target = LAO
+					autonomy_state = autonomy_free
+				}
+			}
+		}
+		if = {
+			limit = {
+				CAM = {
+					exists = yes
+					is_subject_of = ROOT
+				}
+			}
+			OVERLORD = {
+				set_autonomy = {
+					target = CAM
+					autonomy_state = autonomy_free
+				}
+			}
+		}
+		every_owned_state = {
+			limit = {
+				is_controlled_by = ROOT
+				OR = {
+					is_core_of = CAM
+					is_core_of = VIN
+					is_core_of = LAO
+				}
+			}
+			add_resistance_target = {
+				amount = 100 #Vietnam War, here we come!
+				tooltip = LAR_fra_voted_independence_tt
+			}
+		}
+	}
+}
+
+### #  # ### ### ###  #   # ### #  # ### ###  ##  #  #     ###   ##  ###  ###  ### ###      #   #  ##  ###   ## 
+ #  ## #  #  #   #  # #   # #   ## #  #   #  #  # ## #     #  # #  # #  # #  # #   #  #     #   # #  # #  # #   
+ #  # ##  #  ##  ###   # #  ##  # ##  #   #  #  # # ##     ###  #  # ###  #  # ##  ###      # # # #### ###   #  
+ #  #  #  #  #   #  #  # #  #   #  #  #   #  #  # #  #     #  # #  # #  # #  # #   #  #     # # # #  # #  #   # 
+### #  #  #  ### #  #   #   ### #  #  #  ###  ##  #  #     ###   ##  #  # ###  ### #  #      # #  #  # #  # ##  
+
+add_namespace = FRA_syria_intervention
+
+#attackers win syrian intervention
+country_event = {
+	id = FRA_syria_intervention.1
+	title = FRA_syria_intervention.1.t
+	desc = FRA_syria_intervention.1.desc
+	picture = GFX_report_event_france_victory_syria
+	is_triggered_only = yes
+	immediate = {
+		hidden_effect = {
+			if = {
+				limit = { has_template = "Syria Intervention Force" }
+				delete_unit_template_and_units = { division_template = "Syria Intervention Force" }
+			}
+			if = {
+				limit = { has_template = "Syria Defense Force" }
+				delete_unit_template_and_units = { division_template = "Syria Defense Force" }
+			}
+			if = {
+				limit = {
+					NOT = { tag = FRA }
+				}
+				FRA = { country_event = FRA_syria_intervention.11 } #due to border wars being weird, we might end up in a situation where another country is fighting the border war on French behalf. This ensures that the French are kept in the loop
+			}
+		}
+	}
+	option = {
+		name = FRA_syria_intervention.1.a
+		event_target:free_france = {
+			transfer_state = 554
+			transfer_state = 680
+			transfer_state = 677
+			transfer_state = 553
+		}
+	}
+}
+
+#attackers win syrian intervention
+country_event = {
+	id = FRA_syria_intervention.11
+	title = FRA_syria_intervention.1.t
+	desc = FRA_syria_intervention.1.desc
+	picture = GFX_report_event_france_victory_syria
+	is_triggered_only = yes
+	fire_only_once = yes
+	option = {
+		name = FRA_syria_intervention.1.a
+		effect_tooltip = {
+			event_target:free_france = {
+				transfer_state = 554
+				transfer_state = 680
+				transfer_state = 677
+				transfer_state = 553
+			}
+		}
+	}
+}
+
+#defenders win syrian intervention
+country_event = {
+	id = FRA_syria_intervention.2
+	title = FRA_syria_intervention.2.t
+	desc = FRA_syria_intervention.2.desc
+	picture = GFX_report_event_romanian_soldiers
+	immediate = {
+		hidden_effect = {
+			if = {
+				limit = { has_template = "Syria Intervention Force" }
+				delete_unit_template_and_units = { division_template = "Syria Intervention Force" }
+			}
+			if = {
+				limit = { has_template = "Syria Defense Force" }
+				delete_unit_template_and_units = { division_template = "Syria Defense Force" }
+			}
+			if = {
+				limit = {
+					NOT = { tag = FRA }
+				}
+				FRA = { country_event = FRA_syria_intervention.21 } #due to border wars being weird, we might end up in a situation where another country is fighting the border war on French behalf. This ensures that the French are kept in the loop
+			}
+		}
+	}
+	is_triggered_only = yes
+	option = {
+		name = FRA_syria_intervention.2.a
+		army_experience = 5
+	}
+}
+
+#defenders win syrian intervention
+country_event = {
+	id = FRA_syria_intervention.21
+	title = FRA_syria_intervention.2.t
+	desc = FRA_syria_intervention.2.desc
+	picture = GFX_report_event_romanian_soldiers
+	is_triggered_only = yes
+	fire_only_once = yes
+	option = {
+		name = FRA_syria_intervention.2.a
+		army_experience = 5
+	}
+}
+
+#syrian intervention stalls out
+country_event = {
+	id = FRA_syria_intervention.3
+	title = FRA_syria_intervention.3.t
+	desc = FRA_syria_intervention.3.desc
+	picture = GFX_report_event_soldiers_in_france
+	is_triggered_only = yes
+	immediate = {
+		hidden_effect = {
+			if = {
+				limit = { has_template = "Syria Intervention Force" }
+				delete_unit_template_and_units = { division_template = "Syria Intervention Force" }
+			}
+			if = {
+				limit = { has_template = "Syria Defense Force" }
+				delete_unit_template_and_units = { division_template = "Syria Defense Force" }
+			}
+			if = {
+				limit = {
+					NOT = { tag = FRA }
+				}
+				FRA = { country_event = FRA_syria_intervention.31 } #due to border wars being weird, we might end up in a situation where another country is fighting the border war on French behalf. This ensures that the French are kept in the loop
+			}
+		}
+	}
+	option = {
+		name = FRA_syria_intervention.3.a
+	}
+}
+
+#syrian intervention stalls out
+country_event = {
+	id = FRA_syria_intervention.31
+	title = FRA_syria_intervention.3.t
+	desc = FRA_syria_intervention.3.desc
+	picture = GFX_report_event_soldiers_in_france
+
+	is_triggered_only = yes
+	fire_only_once = yes
+	option = {
+		name = FRA_syria_intervention.3.a
+	}
+}
+
+add_namespace = FRA_indochina_intervention
+
+#attackers win indochina intervention
+country_event = {
+	id = FRA_indochina_intervention.1
+	title = FRA_indochina_intervention.1.t
+	desc = FRA_indochina_intervention.1.desc
+	picture = GFX_report_event_france_victory_syria
+	is_triggered_only = yes
+	immediate = {
+		hidden_effect = {
+			if = {
+				limit = { has_template = "Indochina Intervention Force" }
+				delete_unit_template_and_units = { division_template = "Indochina Intervention Force" }
+			}
+			if = {
+				limit = { has_template = "Indochina Defense Force" }
+				delete_unit_template_and_units = { division_template = "Indochina Defense Force" }
+			}
+			if = {
+				limit = {
+					NOT = { tag = FRA }
+				}
+				FRA = { country_event = FRA_indochina_intervention.11 } #due to border wars being weird, we might end up in a situation where another country is fighting the border war on French behalf. This ensures that the French are kept in the loop
+			}
+		}
+	}
+	option = {
+		name = FRA_indochina_intervention.1.a
+		event_target:free_france = {
+			transfer_state = 670
+			transfer_state = 671
+			transfer_state = 741
+		}
+	}
+}
+
+#attackers win indochina intervention
+country_event = {
+	id = FRA_indochina_intervention.11
+	title = FRA_indochina_intervention.1.t
+	desc = FRA_indochina_intervention.1.desc
+	picture = GFX_report_event_france_victory_syria
+	is_triggered_only = yes
+	fire_only_once = yes
+	option = {
+		name = FRA_indochina_intervention.1.a
+		effect_tooltip = {
+			event_target:free_france = {
+				transfer_state = 670
+				transfer_state = 671
+				transfer_state = 74
+			}
+		}
+	}
+}
+
+#defenders win indochina intervention
+country_event = {
+	id = FRA_indochina_intervention.2
+	title = FRA_indochina_intervention.2.t
+	desc = FRA_indochina_intervention.2.desc
+	picture = GFX_report_event_romanian_soldiers
+	is_triggered_only = yes
+	immediate = {
+		hidden_effect = {
+			if = {
+				limit = { has_template = "Indochina Intervention Force" }
+				delete_unit_template_and_units = { division_template = "Indochina Intervention Force" }
+			}
+			if = {
+				limit = { has_template = "Indochina Defense Force" }
+				delete_unit_template_and_units = { division_template = "Indochina Defense Force" }
+			}
+			if = {
+				limit = {
+					NOT = { tag = FRA }
+				}
+				FRA = { country_event = FRA_indochina_intervention.21 } #due to border wars being weird, we might end up in a situation where another country is fighting the border war on French behalf. This ensures that the French are kept in the loop
+			}
+		}
+	}
+	option = {
+		name = FRA_indochina_intervention.2.a
+		army_experience = 5
+	}
+}
+
+#defenders win indochina intervention
+country_event = {
+	id = FRA_indochina_intervention.21
+	title = FRA_indochina_intervention.2.t
+	desc = FRA_indochina_intervention.2.desc
+	picture = GFX_report_event_romanian_soldiers
+	is_triggered_only = yes
+	fire_only_once = yes
+	option = {
+		name = FRA_indochina_intervention.2.a
+		army_experience = 5
+	}
+}
+
+#indochina intervention stalls out
+country_event = {
+	id = FRA_indochina_intervention.3
+	title = FRA_indochina_intervention.3.t
+	desc = FRA_indochina_intervention.3.desc
+	picture = GFX_report_event_soldiers_in_france
+	is_triggered_only = yes
+	immediate = {
+		hidden_effect = {
+			if = {
+				limit = { has_template = "Indochina Intervention Force" }
+				delete_unit_template_and_units = { division_template = "Indochina Intervention Force" }
+			}
+			if = {
+				limit = { has_template = "Indochina Defense Force" }
+				delete_unit_template_and_units = { division_template = "Indochina Defense Force" }
+			}
+			if = {
+				limit = {
+					NOT = { tag = FRA }
+				}
+				FRA = { country_event = FRA_indochina_intervention.31 } #due to border wars being weird, we might end up in a situation where another country is fighting the border war on French behalf. This ensures that the French are kept in the loop
+			}
+		}
+	}
+	option = {
+		name = FRA_indochina_intervention.3.a
+	}
+}
+
+#indochina intervention stalls out
+country_event = {
+	id = FRA_indochina_intervention.31
+	title = FRA_indochina_intervention.3.t
+	desc = FRA_indochina_intervention.3.desc
+	picture = GFX_report_event_soldiers_in_france
+	is_triggered_only = yes
+	fire_only_once = yes
+	option = {
+		name = FRA_indochina_intervention.3.a
+	}
+}
+
+add_namespace = FRA_central_africa_intervention
+
+#attackers win central african intervention
+country_event = {
+	id = FRA_central_africa_intervention.1
+	title = FRA_central_africa_intervention.1.t
+	desc = FRA_central_africa_intervention.1.desc
+	picture = GFX_report_event_france_victory_syria
+	is_triggered_only = yes
+	immediate = {
+		hidden_effect = {
+			if = {
+				limit = { has_template = "Central Africa Intervention Force" }
+				delete_unit_template_and_units = { division_template = "Central Africa Intervention Force" }
+			}
+			if = {
+				limit = { has_template = "Central Africa Defense Force" }
+				delete_unit_template_and_units = { division_template = "Central Africa Defense Force" }
+			}
+			if = {
+				limit = {
+					NOT = { tag = FRA }
+				}
+				FRA = { country_event = FRA_central_africa_intervention.11 } #due to border wars being weird, we might end up in a situation where another country is fighting the border war on French behalf. This ensures that the French are kept in the loop
+			}
+		}
+	}
+	option = {
+		name = FRA_central_africa_intervention.1.a
+		every_state = {
+			limit = {
+				OR = {
+					is_core_of = CHA
+					is_core_of = CMR
+					is_core_of = CAR
+					is_core_of = RCG
+					is_core_of = GAB
+				}
+			}
+			event_target:free_france = {
+				transfer_state = PREV
+			}
+		}
+	}
+}
+
+country_event = {
+	id = FRA_central_africa_intervention.11
+	title = FRA_central_africa_intervention.1.t
+	desc = FRA_central_africa_intervention.1.desc
+	picture = GFX_report_event_france_victory_syria
+	is_triggered_only = yes
+	fire_only_once = yes
+	option = {
+		name = FRA_central_africa_intervention.1.a
+		effect_tooltip = {
+			every_state = {
+				limit = {
+					OR = {
+						is_core_of = CHA
+						is_core_of = CMR
+						is_core_of = CAR
+						is_core_of = RCG
+						is_core_of = GAB
+					}
+				}
+				event_target:free_france = {
+					transfer_state = PREV
+				}
+			}
+		}
+	}
+}
+
+#defenders win central african intervention
+country_event = {
+	id = FRA_central_africa_intervention.2
+	title = FRA_central_africa_intervention.2.t
+	desc = FRA_central_africa_intervention.2.desc
+	picture = GFX_report_event_romanian_soldiers
+	is_triggered_only = yes
+	immediate = {
+		hidden_effect = {
+			if = {
+				limit = { has_template = "Central Africa Intervention Force" }
+				delete_unit_template_and_units = { division_template = "Central Africa Intervention Force" }
+			}
+			if = {
+				limit = { has_template = "Central Africa Defense Force" }
+				delete_unit_template_and_units = { division_template = "Central Africa Defense Force" }
+			}
+			if = {
+				limit = {
+					NOT = { tag = FRA }
+				}
+				FRA = { country_event = FRA_central_africa_intervention.21 } #due to border wars being weird, we might end up in a situation where another country is fighting the border war on French behalf. This ensures that the French are kept in the loop
+			}
+		}
+	}
+	option = {
+		name = FRA_central_africa_intervention.2.a
+		army_experience = 5
+	}
+}
+
+#defenders win central african intervention
+country_event = {
+	id = FRA_central_africa_intervention.21
+	title = FRA_central_africa_intervention.2.t
+	desc = FRA_central_africa_intervention.2.desc
+	picture = GFX_report_event_romanian_soldiers
+	is_triggered_only = yes
+	fire_only_once = yes
+	option = {
+		name = FRA_central_africa_intervention.2.a
+		army_experience = 5
+	}
+}
+
+#central african intervention stalls out
+country_event = {
+	id = FRA_central_africa_intervention.3
+	title = FRA_central_africa_intervention.3.t
+	desc = FRA_central_africa_intervention.3.desc
+	picture = GFX_report_event_soldiers_in_france
+	is_triggered_only = yes
+	immediate = {
+		hidden_effect = {
+			if = {
+				limit = { has_template = "Central Africa Intervention Force" }
+				delete_unit_template_and_units = { division_template = "Central Africa Intervention Force" }
+			}
+			if = {
+				limit = { has_template = "Central Africa Defense Force" }
+				delete_unit_template_and_units = { division_template = "Central Africa Defense Force" }
+			}
+			if = {
+				limit = {
+					NOT = { tag = FRA }
+				}
+				FRA = { country_event = FRA_central_africa_intervention.31 } #due to border wars being weird, we might end up in a situation where another country is fighting the border war on French behalf. This ensures that the French are kept in the loop
+			}
+		}
+	}
+	option = {
+		name = FRA_central_africa_intervention.3.a
+	}
+}
+
+#central african intervention stalls out
+country_event = {
+	id = FRA_central_africa_intervention.31
+	title = FRA_central_africa_intervention.3.t
+	desc = FRA_central_africa_intervention.3.desc
+	picture = GFX_report_event_soldiers_in_france
+	is_triggered_only = yes
+	fire_only_once = yes
+	option = {
+		name = FRA_central_africa_intervention.3.a
+	}
+}
+
+add_namespace = FRA_west_africa_intervention
+
+#attackers win west african intervention
+country_event = {
+	id = FRA_west_africa_intervention.1
+	title = FRA_west_africa_intervention.1.t
+	desc = FRA_west_africa_intervention.1.desc
+	picture = GFX_report_event_france_victory_syria
+	is_triggered_only = yes
+	immediate = {
+		hidden_effect = {
+			if = {
+				limit = { has_template = "West Africa Intervention Force" }
+				delete_unit_template_and_units = { division_template = "West Africa Intervention Force" }
+			}
+			if = {
+				limit = { has_template = "West Africa Defense Force" }
+				delete_unit_template_and_units = { division_template = "West Africa Defense Force" }
+			}
+			if = {
+				limit = {
+					NOT = { tag = FRA }
+				}
+				FRA = { country_event = FRA_west_africa_intervention.11 } #due to border wars being weird, we might end up in a situation where another country is fighting the border war on French behalf. This ensures that the French are kept in the loop
+			}
+		}
+	}
+	option = {
+		name = FRA_west_africa_intervention.1.a
+		every_state = {
+			limit = {
+				OR = {
+					state = 557
+					state = 272
+					state = 556
+					state = 780
+					state = 779
+					state = 778
+					state = 781
+					state = 776
+				}
+			}
+			event_target:free_france = {
+				transfer_state = PREV
+			}
+		}
+	}
+}
+
+#attackers win west african intervention
+country_event = {
+	id = FRA_west_africa_intervention.11
+	title = FRA_west_africa_intervention.1.t
+	desc = FRA_west_africa_intervention.1.desc
+	picture = GFX_report_event_france_victory_syria
+	is_triggered_only = yes
+	fire_only_once = yes
+	option = {
+		name = FRA_west_africa_intervention.1.a
+		effect_tooltip = {
+			every_state = {
+				limit = {
+					OR = {
+						state = 557
+						state = 272
+						state = 556
+						state = 780
+						state = 779
+						state = 778
+						state = 781
+						state = 776
+					}
+				}
+				event_target:free_france = {
+					transfer_state = PREV
+				}
+			}
+		}
+	}
+}
+
+#defenders win west african intervention
+country_event = {
+	id = FRA_west_africa_intervention.2
+	title = FRA_west_africa_intervention.2.t
+	desc = FRA_west_africa_intervention.2.desc
+	picture = GFX_report_event_romanian_soldiers
+	is_triggered_only = yes
+	immediate = {
+		hidden_effect = {
+			if = {
+				limit = { has_template = "West Africa Intervention Force" }
+				delete_unit_template_and_units = { division_template = "West Africa Intervention Force" }
+			}
+			if = {
+				limit = { has_template = "West Africa Defense Force" }
+				delete_unit_template_and_units = { division_template = "West Africa Defense Force" }
+			}
+			if = {
+				limit = {
+					NOT = { tag = FRA }
+				}
+				FRA = { country_event = FRA_west_africa_intervention.21 } #due to border wars being weird, we might end up in a situation where another country is fighting the border war on French behalf. This ensures that the French are kept in the loop
+			}
+		}
+	}
+	option = {
+		name = FRA_west_africa_intervention.2.a
+		army_experience = 5
+	}
+}
+
+#defenders win west african intervention
+country_event = {
+	id = FRA_west_africa_intervention.21
+	title = FRA_west_africa_intervention.2.t
+	desc = FRA_west_africa_intervention.2.desc
+	picture = GFX_report_event_romanian_soldiers
+	is_triggered_only = yes
+	fire_only_once = yes
+	option = {
+		name = FRA_west_africa_intervention.2.a
+		army_experience = 5
+	}
+}
+
+#west african intervention stalls out
+country_event = {
+	id = FRA_west_africa_intervention.3
+	title = FRA_west_africa_intervention.3.t
+	desc = FRA_west_africa_intervention.3.desc
+	picture = GFX_report_event_soldiers_in_france
+	is_triggered_only = yes
+	immediate = {
+		hidden_effect = {
+			if = {
+				limit = { has_template = "West Africa Intervention Force" }
+				delete_unit_template_and_units = { division_template = "West Africa Intervention Force" }
+			}
+			if = {
+				limit = { has_template = "West Africa Defense Force" }
+				delete_unit_template_and_units = { division_template = "West Africa Defense Force" }
+			}
+			if = {
+				limit = {
+					NOT = { tag = FRA }
+				}
+				FRA = { country_event = FRA_west_africa_intervention.31 } #due to border wars being weird, we might end up in a situation where another country is fighting the border war on French behalf. This ensures that the French are kept in the loop
+			}
+		}
+	}
+	option = {
+		name = FRA_west_africa_intervention.3.a
+	}
+}
+
+#west african intervention stalls out
+country_event = {
+	id = FRA_west_africa_intervention.31
+	title = FRA_west_africa_intervention.3.t
+	desc = FRA_west_africa_intervention.3.desc
+	picture = GFX_report_event_soldiers_in_france
+	is_triggered_only = yes
+	fire_only_once = yes
+	option = {
+		name = FRA_west_africa_intervention.3.a
+	}
+}
+
+ ##   ##  #   # ###  ### #  #  ##  ##  ### ###     ### ###  ##  #   #   # 
+#  # #  # ## ## #  # #   ## # #   #  #  #  #        #   #  #  # #    # #  
+#    #  # # # # ###  ##  # ##  #  ####  #  ##       #   #  #### #     #   
+#  # #  # #   # #    #   #  #   # #  #  #  #        #   #  #  # #     #   
+ ##   ##  #   # #    ### #  # ##  #  #  #  ###     ###  #  #  # ###   #   
+
+add_namespace = lar_compensate_italy
+
+#initial event to Italy - France proposes to turn over Djibouti
+country_event = {
+	id = lar_compensate_italy.1
+	title = lar_compensate_italy.1.t
+	desc = lar_compensate_italy.1.desc
+	picture = GFX_report_event_generic_conference
+	is_triggered_only = yes
+	option = {
+		name = lar_compensate_italy.1.a #agree
+		ai_chance = {
+			factor = 100
+		}
+		FRA = {
+			country_event = lar_compensate_italy.2
+		}
+		effect_tooltip = {
+			ITA = { transfer_state = 268 }
+			FRA = { add_to_faction = ITA }
+		}
+	}
+
+	option = {
+		name = lar_compensate_italy.1.b #refuse
+		ai_chance = {
+			factor = 0
+		}
+		FRA = {
+			country_event = lar_compensate_italy.3
+		}
+	}
+}
+
+# rasponse event for France - Italy agrees
+country_event = {
+	id = lar_compensate_italy.2
+	title = lar_compensate_italy.2.t
+	desc = lar_compensate_italy.2.desc
+	picture = GFX_report_event_generic_read_write
+	is_triggered_only = yes
+	option = {
+		name = lar_compensate_italy.2.a #agree
+		ai_chance = {
+			factor = 100
+		}
+		if = {
+			limit = {
+				268 = {
+					CONTROLLER = {
+						OR = {
+							TAG = ROOT
+							is_subject_of = ROOT
+						}
+					}
+				}
+			}
+			ITA = { transfer_state = 268 }
+		}
+		else = {
+			ITA = {
+				add_state_claim = 268
+			}
+		}
+		FRA = { add_to_faction = ITA }
+	}
+}
+#response event for France - Italy refuses
+country_event = {
+	id = lar_compensate_italy.3
+	title = lar_compensate_italy.3.t
+	desc = lar_compensate_italy.3.desc
+	picture = GFX_report_event_fascist_speech
+	is_triggered_only = yes
+	option = {
+		name = lar_compensate_italy.3.a #agree
+		ai_chance = {
+			factor = 100
+		}
+	}
+}
+
+### #  # ### ### ###  #   # ### #  # ### ###  ##  #  #     ### #  #      ##  ###  ### ###  ##  ### 
+ #  ## #  #  #   #  # #   # #   ## #  #   #  #  # ## #      #  ## #     #    #  # #   #   #  # #   
+ #  # ##  #  ##  ###   # #  ##  # ##  #   #  #  # # ##      #  # ##     # ## ###  ##  ##  #    ##  
+ #  #  #  #  #   #  #  # #  #   #  #  #   #  #  # #  #      #  #  #     #  # #  # #   #   #  # #   
+### #  #  #  ### #  #   #   ### #  #  #  ###  ##  #  #     ### #  #      ##  #  # ### ###  ##  ### 
+
+add_namespace = lar_intervention_in_greece
+
+#initial event to Italy - France proposes to intervene in Greece
+country_event = {
+	id = lar_intervention_in_greece.1
+	title = lar_intervention_in_greece.1.t
+	desc = lar_intervention_in_greece.1.desc
+	picture = GFX_report_event_generic_read_write
+	is_triggered_only = yes
+	option = {
+		name = lar_intervention_in_greece.1.a #agree
+		ai_chance = {
+			factor = 100
+		}
+		FRA = {
+			country_event = lar_intervention_in_greece.2
+		}
+		effect_tooltip = {
+			ITA = { 
+				add_state_claim = 185
+				add_state_claim = 731
+				add_state_claim = 184
+				add_state_claim = 47
+				add_state_claim = 186
+			}
+			FRA = {
+				add_state_claim = 187
+				add_state_claim = 182
+			}
+		}
+	}
+
+	option = {
+		name = lar_intervention_in_greece.1.b #refuse
+		ai_chance = {
+			factor = 0
+		}
+		FRA = {
+			country_event = lar_intervention_in_greece.3
+		}
+	}
+}
+
+# rasponse event for France - Italy agrees
+country_event = {
+	id = lar_intervention_in_greece.2
+	title = lar_intervention_in_greece.2.t
+	desc = lar_intervention_in_greece.2.desc
+	picture = GFX_report_event_france_parade
+	is_triggered_only = yes
+	option = {
+		name = lar_intervention_in_greece.2.a #agree
+		ai_chance = {
+			factor = 100
+		}
+		FROM = {
+			add_state_claim = 185
+			add_state_claim = 731
+			add_state_claim = 184
+			add_state_claim = 47
+			add_state_claim = 186
+		}
+		FRA = {
+			add_state_claim = 187
+			add_state_claim = 182
+		}
+	}
+}
+#response event for France - Italy refuses
+country_event = {
+	id = lar_intervention_in_greece.3
+	title = lar_intervention_in_greece.3.t
+	desc = lar_intervention_in_greece.3.desc
+	picture = GFX_report_event_fascists_posing
+	is_triggered_only = yes
+	option = {
+		name = lar_intervention_in_greece.3.a #agree
+		ai_chance = {
+			factor = 100
+		}
+	}
+}
+
+###   ##  #   # ### #  #  ##  ### ###     ### #  # ###     #   # ### ###  ###  #   ###     ###  ##   ## ### 
+#  # #  # ## ##  #  ## # #  #  #  #        #  #  # #       ## ##  #  #  # #  # #   #       #   #  # #    #  
+#  # #  # # # #  #  # ## ####  #  ##       #  #### ##      # # #  #  #  # #  # #   ##      ##  ####  #   #  
+#  # #  # #   #  #  #  # #  #  #  #        #  #  # #       #   #  #  #  # #  # #   #       #   #  #   #  #  
+###   ##  #   # ### #  # #  #  #  ###      #  #  # ###     #   # ### ###  ###  ### ###     ### #  # ##   #  
+
+add_namespace = lar_dominate_the_middle_east
+
+#initial event - France wants to control country
+country_event = {
+	id = lar_dominate_the_middle_east.1
+	title = lar_dominate_the_middle_east.1.t
+	desc = lar_dominate_the_middle_east.1.desc
+	picture = GFX_report_event_french_tanks
+	is_triggered_only = yes
+	option = {
+		name = lar_dominate_the_middle_east.1.a #agree
+		ai_chance = {
+			factor = 70
+		}
+		FROM = {
+			country_event = lar_dominate_the_middle_east.2
+		}
+		effect_tooltip = {
+			FROM = {
+				puppet = ROOT
+			}
+		}
+	}
+
+	option = {
+		name = lar_dominate_the_middle_east.1.b #refuse
+		ai_chance = {
+			factor = 30
+		}
+		FROM = {
+			country_event = lar_dominate_the_middle_east.3
+		}
+		effect_tooltip = {
+			FROM = {
+				create_wargoal = {
+					target = ROOT
+					type = puppet_wargoal_focus
+				}
+			}
+		}
+	}
+}
+
+# rasponse event for France - country agrees
+country_event = {
+	id = lar_dominate_the_middle_east.2
+	title = lar_dominate_the_middle_east.2.t
+	desc = lar_dominate_the_middle_east.2.desc
+	picture = GFX_report_event_france_parade
+	is_triggered_only = yes
+	option = {
+		name = lar_dominate_the_middle_east.2.a #agree
+		ai_chance = {
+			factor = 100
+		}
+		puppet = FROM
+	}
+}
+#response event for France - country refuses
+country_event = {
+	id = lar_dominate_the_middle_east.3
+	title = lar_dominate_the_middle_east.3.t
+	desc = lar_dominate_the_middle_east.3.desc
+	picture = GFX_report_event_generic_battle
+	is_triggered_only = yes
+	option = {
+		name = lar_dominate_the_middle_east.3.a #agree
+		ai_chance = {
+			factor = 80
+		}
+		create_wargoal = {
+				target = FROM
+				type = puppet_wargoal_focus
+			}
+	}
+	option = {
+		name = lar_dominate_the_middle_east.3.b #back down
+		ai_chance = {
+			factor = 20
+		}
+	}
+}
+
+ ## ###  #  # ### ###  ###  ##      ##  ###     ### #  # ### #   #  # ### #  #  ##  ### 
+#   #  # #  # #   #  # #   #       #  # #        #  ## # #   #   #  # #   ## # #  # #   
+ #  ###  #### ##  ###  ##   #      #  # ##       #  # ## ##  #   #  # ##  # ## #    ##  
+  # #    #  # #   #  # #     #     #  # #        #  #  # #   #   #  # #   #  # #  # #   
+##  #    #  # ### #  # ### ##       ##  #       ### #  # #   ###  ##  ### #  #  ##  ### 
+
+add_namespace = lar_spheres_of_influence
+
+#initial event for Germany - France wants to split up spheres of interest in the benelux
+country_event = {
+	id = lar_spheres_of_influence.1
+	title = lar_spheres_of_influence.1.t
+	desc = lar_spheres_of_influence.1.desc
+	picture = GFX_report_event_generic_conference
+	is_triggered_only = yes
+	option = {
+		name = lar_spheres_of_influence.1.a #agree
+		ai_chance = {
+			factor = 70
+		}
+		FROM = {
+			country_event = lar_spheres_of_influence.2
+		}
+		effect_tooltip = {
+			ROOT = {
+				add_state_claim = 8
+				add_state_claim = 7
+				add_state_claim = 35
+				add_state_claim = 36
+				add_to_faction = FROM
+			}
+			FROM = {
+				add_state_claim = 34
+				add_state_claim = 6
+			}
+		}
+	}
+
+	option = {
+		name = lar_spheres_of_influence.1.b #refuse
+		ai_chance = {
+			factor = 30
+		}
+		FROM = {
+			country_event = lar_spheres_of_influence.3
+			set_country_flag = lar_germany_refused_spheres
+		}
+	}
+}
+
+# rasponse event for France - country agrees
+country_event = {
+	id = lar_spheres_of_influence.2
+	title = lar_spheres_of_influence.2.t
+	desc = lar_spheres_of_influence.2.desc
+	picture = GFX_report_event_german_speech
+	is_triggered_only = yes
+	option = {
+		name = lar_spheres_of_influence.2.a #agree
+		ai_chance = {
+			factor = 100
+		}
+		FROM = {
+			add_state_claim = 8
+			add_state_claim = 7
+			add_state_claim = 35
+			add_state_claim = 36
+			add_to_faction = ROOT
+		}
+		ROOT = {
+			add_state_claim = 34
+			add_state_claim = 6
+		}
+		hidden_effect = {
+			news_event = { id = lar_news.7 days = 3 random_days = 7 }
+		}
+	}
+}
+#response event for France - country refuses
+country_event = {
+	id = lar_spheres_of_influence.3
+	title = lar_spheres_of_influence.3.t
+	desc = lar_spheres_of_influence.3.desc
+	picture = GFX_report_event_generic_read_write
+	is_triggered_only = yes
+	option = {
+		name = lar_spheres_of_influence.3.a #agree
+		ai_chance = {
+			factor = 80
+		}
+		add_state_claim = 34
+		add_state_claim = 6
+		add_state_claim = 8
+		add_state_claim = 7
+		add_state_claim = 35
+		add_state_claim = 36
+	}
+}
+
+ ##  #   ###  ##  #  #     ###  ### #    ##  ### #  # #   # 
+#  # #    #  #    ## #     #  # #   #   #     #  #  # ## ## 
+#### #    #  # ## # ##     ###  ##  #   # ##  #  #  # # # # 
+#  # #    #  #  # #  #     #  # #   #   #  #  #  #  # #   # 
+#  # ### ###  ##  #  #     ###  ### ###  ##  ###  ##  #   # 
+
+add_namespace = lar_align_belgium
+
+#initial event - France wants to control country
+country_event = {
+	id = lar_align_belgium.1
+	title = lar_align_belgium.1.t
+	desc = lar_align_belgium.1.desc
+	picture = GFX_report_event_fascist_speech
+	is_triggered_only = yes
+	option = {
+		name = lar_align_belgium.1.a #agree
+		ai_chance = {
+			factor = 70
+		}
+		FROM = {
+			country_event = lar_align_belgium.2
+		}
+		effect_tooltip = {
+			FROM = {
+				puppet = PREV
+			}
+		}
+	}
+
+	option = {
+		name = lar_align_belgium.1.b #refuse
+		ai_chance = {
+			factor = 30
+		}
+		FROM = {
+			country_event = lar_align_belgium.3
+		}
+		effect_tooltip = {
+			create_wargoal = {
+				target = ROOT
+				type = puppet_wargoal_focus
+			}
+		}
+	}
+}
+
+# rasponse event for France - country agrees
+country_event = {
+	id = lar_align_belgium.2
+	title = lar_align_belgium.2.t
+	desc = lar_align_belgium.2.desc
+	Picture = GFX_report_event_generic_sign_treaty1
+	is_triggered_only = yes
+	option = {
+		name = lar_align_belgium.2.a #agree
+		ai_chance = {
+			factor = 100
+		}
+		puppet = FROM
+	}
+}
+#response event for France - country refuses
+country_event = {
+	id = lar_align_belgium.3
+	title = lar_align_belgium.3.t
+	desc = lar_align_belgium.3.desc
+	picture = GFX_report_event_generic_defensive_preparations
+	is_triggered_only = yes
+	option = {
+		name = lar_align_belgium.3.a #agree
+		ai_chance = {
+			factor = 80
+		}
+		create_wargoal = {
+				target = FROM
+				type = puppet_wargoal_focus
+			}
+	}
+	option = {
+		name = lar_align_belgium.3.b #back down
+		ai_chance = {
+			factor = 20
+		}
+	}
+}
+
+ ## ###  #   ### ###     ###  ### #    ##  ### #  # #   # 
+#   #  # #    #   #      #  # #   #   #     #  #  # ## ## 
+ #  ###  #    #   #      ###  ##  #   # ##  #  #  # # # # 
+  # #    #    #   #      #  # #   #   #  #  #  #  # #   # 
+##  #    ### ###  #      ###  ### ###  ##  ###  ##  #   # 
+
+
+add_namespace = lar_split_belgium
+
+#initial event - France wants to control country
+country_event = {
+	id = lar_split_belgium.1
+	title = lar_split_belgium.1.t
+	desc = lar_split_belgium.1.desc
+	picture = GFX_report_event_fascist_speech
+	is_triggered_only = yes
+	option = {
+		name = lar_split_belgium.1.a #agree
+		ai_chance = {
+			factor = 40
+		}
+		FRA = {
+			country_event = lar_split_belgium.2
+		}
+		effect_tooltip = {
+			FRA = {
+				puppet = PREV
+				transfer_state = 34
+			}
+		}
+	}
+
+	option = {
+		name = lar_split_belgium.1.b #refuse
+		ai_chance = {
+			factor = 60
+		}
+		FRA = {
+			country_event = lar_split_belgium.3
+		}
+		effect_tooltip = {
+			create_wargoal = {
+				target = ROOT
+				type = puppet_wargoal_focus
+			}
+		}
+	}
+}
+
+# rasponse event for France - country agrees
+country_event = {
+	id = lar_split_belgium.2
+	title = lar_split_belgium.2.t
+	desc = lar_split_belgium.2.desc
+	Picture = GFX_report_event_generic_sign_treaty1
+	is_triggered_only = yes
+	option = {
+		name = lar_split_belgium.2.a #agree
+		ai_chance = {
+			factor = 100
+		}
+		puppet = FROM
+		transfer_state = 34
+	}
+}
+#response event for France - Belgium refuses
+country_event = {
+	id = lar_split_belgium.3
+	title = lar_split_belgium.3.t
+	desc = lar_split_belgium.3.desc
+	Picture = GFX_report_event_generic_defensive_preparations
+	is_triggered_only = yes
+	option = {
+		name = lar_split_belgium.3.a #agree
+		ai_chance = {
+			factor = 80
+		}
+		create_wargoal = {
+			target = FROM
+			type = puppet_wargoal_focus
+		}
+	}
+	option = {
+		name = lar_split_belgium.3.b #back down
+		ai_chance = {
+			factor = 20
+		}
+	}
+}
+
+ ##   ##  #  #  ##  ###  ##  ## ###  ##  #  #  ##     ###  ##      ### ###  ##  #   #   # 
+#  # #  # ## # #  # #   #   #    #  #  # ## # #        #  #  #      #   #  #  # #    # #  
+#    #  # # ## #    ##   #   #   #  #  # # ##  #       #  #  #      #   #  #### #     #   
+#  # #  # #  # #  # #     #   #  #  #  # #  #   #      #  #  #      #   #  #  # #     #   
+ ##   ##  #  #  ##  ### ##  ##  ###  ##  #  # ##       #   ##      ###  #  #  # ###   #   
+
+add_namespace = lar_concessions_to_italy
+
+#initial event for ENG - France wants to appease Italy to pull them over to their side
+country_event = {
+	id = lar_concessions_to_italy.1
+	title = lar_concessions_to_italy.1.t
+	desc = lar_concessions_to_italy.1.desc
+	picture = GFX_report_event_mussolini_hotel
+	is_triggered_only = yes
+	option = {
+		name = lar_concessions_to_italy.1.a #agree
+		ai_chance = {
+			factor = 40
+		}
+		FRA = {
+			country_event = lar_concessions_to_italy.2
+		}
+		effect_tooltip = {
+			ITA = {
+				transfer_state = 269
+				transfer_state = 268
+			}
+			custom_effect_tooltip = lar_concessions_italy_tt
+		}
+	}
+
+	option = {
+		name = lar_concessions_to_italy.1.b #refuse
+		ai_chance = {
+			factor = 60
+		}
+		FRA = {
+			country_event = lar_concessions_to_italy.3
+		}
+	}
+}
+
+# rasponse event for France - country agrees
+country_event = {
+	id = lar_concessions_to_italy.2
+	title = lar_concessions_to_italy.2.t
+	desc = lar_concessions_to_italy.2.desc
+	picture = GFX_report_event_generic_sign_treaty1
+	is_triggered_only = yes
+	option = {
+		name = lar_concessions_to_italy.2.a #agree
+		ai_chance = {
+			factor = 100
+		}
+		ITA = {
+			country_event = lar_concessions_to_italy.4
+		}
+	}
+}
+#response event for France - country refuses
+country_event = {
+	id = lar_concessions_to_italy.3
+	title = lar_concessions_to_italy.3.t
+	desc = lar_concessions_to_italy.3.desc
+	picture = GFX_report_event_fascist_gathering
+	is_triggered_only = yes
+	option = {
+		name = lar_concessions_to_italy.3.a #agree
+		ai_chance = {
+			factor = 80
+		}
+		ITA = {
+			country_event = lar_concessions_to_italy.5
+		}
+	}
+}
+
+# rasponse event for Italy - France and Britain offer consessions
+country_event = {
+	id = lar_concessions_to_italy.4
+	title = lar_concessions_to_italy.4.t
+	desc = lar_concessions_to_italy.4.desc
+	picture = GFX_report_event_generic_conference
+	is_triggered_only = yes
+	option = {
+		name = lar_concessions_to_italy.4.a #agree
+		ai_chance = {
+			factor = 80
+		}
+		set_global_flag = ITA_agrees_ENG_FRA_concessions
+		effect_tooltip = {
+			transfer_state = 268
+			transfer_state = 269
+		}
+		custom_effect_tooltip = LAR_concessions_stresa_front_tt
+		hidden_effect = {
+			FROM = {
+			country_event = lar_concessions_to_italy.6
+			}
+			FROM.FROM = {
+				country_event = lar_concessions_to_italy.6
+			}
+		}
+	}
+	option = {
+		name = lar_concessions_to_italy.4.b #no deal
+		ai_chance = {
+			factor = 20
+		}
+		FROM = {
+			country_event = lar_concessions_to_italy.7
+		}
+		FROM.FROM = {
+			country_event = lar_concessions_to_italy.7
+		}
+		
+	}
+}
+#response event for Italy - only France offers concessions
+country_event = {
+	id = lar_concessions_to_italy.5
+	title = lar_concessions_to_italy.5.t
+	desc = lar_concessions_to_italy.5.desc
+	picture = GFX_report_event_generic_conference
+	is_triggered_only = yes
+	option = {
+		name = lar_concessions_to_italy.5.a #agree
+		ai_chance = {
+			factor = 80
+		}
+		set_global_flag = ITA_agrees_FRA_concessions
+		effect_tooltip = {
+			transfer_state = 268
+		}
+		custom_effect_tooltip = LAR_concessions_stresa_front_tt
+		hidden_effect = {
+		FROM = {
+			country_event = lar_concessions_to_italy.6
+			}
+		}
+	}
+	option = {
+		name = lar_concessions_to_italy.5.b #no deal
+		ai_chance = {
+			factor = 20
+		}
+		FROM = {
+			country_event = lar_concessions_to_italy.7
+		}
+	}
+}
+#notification event - Italy agrees
+country_event = {
+	id = lar_concessions_to_italy.6
+	title = lar_concessions_to_italy.6.t
+	desc = lar_concessions_to_italy.6.desc
+	picture = GFX_report_event_fascist_speech
+	is_triggered_only = yes
+	option = {
+		name = lar_concessions_to_italy.6.a #agree
+		ai_chance = {
+			factor = 80
+		}
+		set_country_flag = lar_france_stresa_front_italy_agreed
+	}
+}
+# notification event - Italy refuses
+country_event = {
+	id = lar_concessions_to_italy.7
+	title = lar_concessions_to_italy.7.t
+	desc = lar_concessions_to_italy.7.desc
+	picture = GFX_report_event_fascist_gathering
+	is_triggered_only = yes
+	option = {
+		name = lar_concessions_to_italy.7.a #agree
+		ai_chance = {
+			factor = 80
+		}
+	}
+}
+
+###   ##  ### ### ### #   #     ### #  # ###      ## ### ###  ###  ##  ##      ### ###   ##  #  # ### 
+#  # #  #  #   #  #    # #       #  #  # #       #    #  #  # #   #   #  #     #   #  # #  # ## #  #  
+###  ####  #   #  ##    #        #  #### ##       #   #  ###  ##   #  ####     ##  ###  #  # # ##  #  
+#  # #  #  #   #  #     #        #  #  # #         #  #  #  # #     # #  #     #   #  # #  # #  #  #  
+#  # #  #  #  ### #     #        #  #  # ###     ##   #  #  # ### ##  #  #     #   #  #  ##  #  #  #  
+
+add_namespace = lar_ratify_the_stresa_front
+
+#initial event for Italy
+country_event = {
+	id = lar_ratify_the_stresa_front.1
+	title = lar_ratify_the_stresa_front.1.t
+	desc = lar_ratify_the_stresa_front.1.desc
+	picture = GFX_report_event_generic_sign_treaty1
+	is_triggered_only = yes
+	option = {
+		name = lar_ratify_the_stresa_front.1.a #agree
+		ai_chance = {
+			factor = 80
+		}
+		FRA = {
+			country_event = lar_ratify_the_stresa_front.2
+		}
+		effect_tooltip = { transfer_state = 268 }
+		if = {
+			limit = {
+				has_global_flag = ITA_agrees_ENG_FRA_concessions
+			}
+			effect_tooltip = { transfer_state = 269 }
+		}
+		add_ai_strategy = {
+			type = alliance
+			id = FROM
+			value = 200
+		}
+		if = {
+			limit = {
+				country_exists = AUS
+				AUS = {
+					is_subject = no
+					is_major = no
+					has_war = no
+					NOT = {
+						is_in_faction_with = GER
+					}
+				}
+			}
+			give_guarantee = AUS
+		}
+	}
+
+	option = {
+		name = lar_ratify_the_stresa_front.1.b #refuse
+		ai_chance = {
+			factor = 20
+			modifier = {
+				has_global_flag = ITA_agrees_ENG_FRA_concessions
+				factor = 0
+			}
+		}
+		FRA = {
+			country_event = lar_ratify_the_stresa_front.3
+		}
+		ENG = {
+			country_event = lar_ratify_the_stresa_front.3
+		}
+	}
+}
+
+# event for France - Italy has agreed, do we want to hand over territory in exchange for an alliance?
+country_event = {
+	id = lar_ratify_the_stresa_front.2
+	title = lar_ratify_the_stresa_front.1.t
+	desc = lar_ratify_the_stresa_front.2.desc
+	picture = GFX_report_event_generic_sign_treaty2
+	is_triggered_only = yes
+	option = {
+		name = lar_ratify_the_stresa_front.2.a #agree
+		ai_chance = {
+			factor = 80
+		}
+		if = { 
+			limit = {
+				is_guaranteed_by = SOV
+			}
+			set_country_flag = Franco_soviet_guaarantee 
+		}
+		ITA = {
+			transfer_state = 268
+		}
+		if = {
+			limit = { is_in_faction = yes }
+			if = {
+				limit = { is_faction_leader = yes }
+				add_to_faction = ITA
+				else = {
+					random_other_country = {
+						limit = { 
+							is_faction_leader = yes
+							is_in_faction_with = ROOT
+						}
+						add_to_faction = ITA
+					}
+				}
+			}
+		}
+		else = {
+			create_faction = FRA_stresa_front
+			add_to_faction = ITA
+		}
+		if = {
+			limit = { has_global_flag = ITA_agrees_ENG_FRA_concessions }
+			ENG = {
+				country_event = lar_ratify_the_stresa_front.4
+			}
+		}
+		else = {
+			hidden_effect = { news_event = { id = lar_news.5 days = 3 random_days = 5 } }
+		}
+		if = {
+			limit = {
+				country_exists = AUS
+				AUS = {
+					is_subject = no
+					is_major = no
+					has_war = no
+					NOT = {
+						is_in_faction_with = GER
+					}
+				}
+			}
+			give_guarantee = AUS
+		}
+		if = {
+			limit = {
+				has_country_flag = Franco_soviet_guaarantee
+			}
+			give_guarantee = SOV
+			SOV = { give_guarantee = ROOT }
+		}
+	}
+
+	option = {
+		name = lar_ratify_the_stresa_front.2.b #refuse
+		ai_chance = {
+			factor = 20
+			modifier = {
+				has_global_flag = ITA_agrees_ENG_FRA_concessions
+				factor = 0
+			}
+		}
+		ITA = {
+			country_event = lar_ratify_the_stresa_front.3
+		}
+		ENG = {
+			country_event = lar_ratify_the_stresa_front.3
+		}
+	}
+}
+
+#notification - country has refused to ratify
+country_event = {
+	id = lar_ratify_the_stresa_front.3
+	title = lar_ratify_the_stresa_front.3.t
+	desc = lar_ratify_the_stresa_front.3.desc
+	picture = GFX_report_event_worried_french
+	is_triggered_only = yes
+	option = {
+		name = lar_ratify_the_stresa_front.3.a #agree
+		ai_chance = {
+			factor = 80
+		}
+		
+	}
+}
+
+# event for Britain - Italy has agreed, do we want to hand over territory in exchange for an alliance?
+country_event = {
+	id = lar_ratify_the_stresa_front.4
+	title = lar_ratify_the_stresa_front.1.t
+	desc = lar_ratify_the_stresa_front.4.desc
+	picture = GFX_report_event_generic_sign_treaty2
+	is_triggered_only = yes
+	option = {
+		name = lar_ratify_the_stresa_front.4.a #agree
+		ai_chance = {
+			factor = 80
+		}
+		ITA = {
+			transfer_state = 269
+		}
+		set_global_flag = LaR_Britain_Stresa_Concessions
+		if = {
+			limit = {
+				FRA = { 
+					is_faction_leader = yes 
+					NOT = {
+						is_in_faction_with = ROOT
+					}
+				}
+			}
+			every_other_country = {
+				limit = {
+					is_in_faction_with = ROOT
+					is_subject_of = ROOT
+				}
+				FRA = {
+					add_to_faction = PREV #merge british colonies into new faction
+				}
+			}
+			every_other_country = {
+				limit = {
+					is_in_faction_with = ROOT
+					NOT = { is_subject_of = ROOT }
+				}
+				FRA = {
+					PREV = {
+						country_event = generic.5
+					}
+				}
+			}
+			FRA = { add_to_faction = ROOT }
+		}
+		if = {
+			limit = {
+				country_exists = AUS
+				AUS = {
+					is_subject = no
+					is_major = no
+					has_war = no
+					NOT = {
+						is_in_faction_with = GER
+					}
+				}
+			}
+			give_guarantee = AUS
+		}
+		hidden_effect = { news_event = { id = lar_news.5 days = 3 random_days = 5 } }
+	}
+
+	option = {
+		name = lar_ratify_the_stresa_front.4.b #refuse
+		ai_chance = {
+			factor = 20
+			modifier = {
+				has_global_flag = ITA_agrees_ENG_FRA_concessions
+				factor = 0
+			}
+		}
+		ITA = {
+			country_event = lar_ratify_the_stresa_front.3
+		}
+		FRA = {
+			country_event = lar_ratify_the_stresa_front.3
+		}
+	}
+}
+
+### ###   ##  #  #  ##   ##      ##  ##  #   # ### ### ###     ### ###  ###  ##  ### #   # 
+#   #  # #  # ## # #  # #  #    #   #  # #   #  #  #    #       #  #  # #   #  #  #   # #  
+##  ###  #### # ## #    #  # ##  #  #  #  # #   #  ##   #       #  ###  ##  ####  #    #   
+#   #  # #  # #  # #  # #  #      # #  #  # #   #  #    #       #  #  # #   #  #  #    #   
+#   #  # #  # #  #  ##   ##     ##   ##    #   ### ###  #       #  #  # ### #  #  #    #   
+
+add_namespace = lar_franco_soviet_treaty
+
+#initial event - France offers treaty
+country_event = {
+	id = lar_franco_soviet_treaty.1
+	title = lar_franco_soviet_treaty.1.t
+	desc = lar_franco_soviet_treaty.1.desc
+	picture = GFX_report_event_stalin_02
+	is_triggered_only = yes
+	option = {
+		name = lar_franco_soviet_treaty.1.a #agree
+		ai_chance = {
+			factor = 40
+		}
+		FRA = {
+			country_event = lar_franco_soviet_treaty.2
+		}
+		effect_tooltip = {
+			FRA = {
+				give_guarantee = SOV
+			}
+			give_guarantee = FRA
+		}
+	}
+
+	option = {
+		name = lar_franco_soviet_treaty.1.b #refuse
+		ai_chance = {
+			factor = 60
+			modifier = {
+				FRA = { has_completed_focus = FRA_form_the_popular_front }
+				factor = 0.2
+			}
+		}
+		FRA = {
+			country_event = lar_franco_soviet_treaty.3
+		}
+	}
+}
+
+# rasponse event for France - country agrees
+country_event = {
+	id = lar_franco_soviet_treaty.2
+	title = lar_franco_soviet_treaty.2.t
+	desc = lar_franco_soviet_treaty.2.desc
+	picture = GFX_report_event_generic_sign_treaty2
+	is_triggered_only = yes
+	option = {
+		name = lar_franco_soviet_treaty.2.a #agree
+		ai_chance = {
+			factor = 100
+		}
+		give_guarantee = FROM
+		FROM = { give_guarantee = ROOT }
+		
+	}
+}
+#response event for France - soviets refuse
+country_event = {
+	id = lar_franco_soviet_treaty.3
+	title = lar_franco_soviet_treaty.3.t
+	desc = lar_franco_soviet_treaty.3.desc
+	picture = GFX_report_event_stalin_meeting
+	is_triggered_only = yes
+	option = {
+		name = lar_franco_soviet_treaty.3.a #agree
+		ai_chance = {
+			factor = 80
+		}
+	}
+}
+
+### #  # ###      ### #  # ###      ##   ##   ##  #  # ###   ##  ### ###  ##  #  # 
+#   ## # #  #      #  #  # #       #  # #  # #  # #  # #  # #  #  #   #  #  # ## # 
+##  # ## #  #      #  #### ##      #  # #    #    #  # ###  ####  #   #  #  # # ## 
+#   #  # #  #      #  #  # #       #  # #  # #  # #  # #    #  #  #   #  #  # #  # 
+### #  # ###       #  #  # ###      ##   ##   ##   ##  #    #  #  #  ###  ##  #  # 
+
+add_namespace = lar_end_the_occupation
+
+#initial event for Germany - vichy wants to end the occupation and join the axis
+country_event = {
+	id = lar_end_the_occupation.1
+	title = lar_end_the_occupation.1.t
+	desc = lar_end_the_occupation.1.desc
+	picture = GFX_report_event_pierre_laval
+
+	is_triggered_only = yes
+
+	option = {
+		name = lar_end_the_occupation.1.a #agree
+		ai_chance = {
+			factor = 80
+		}
+		FROM = { country_event = lar_end_the_occupation.2 }
+		effect_tooltip = {
+			every_state = {
+				limit = {
+					is_core_of = FROM
+					is_controlled_by = ROOT
+				}
+				FROM = { transfer_state = PREV }
+			}
+		}
+	}
+	option = {
+		name = lar_end_the_occupation.1.b #refuse
+		ai_chance = {
+			factor = 20
+			modifier = {
+				is_in_faction_with = FROM
+				factor = 0
+			}
+			modifier = {
+				FROM = {
+					has_war = yes
+					any_enemy_country = {
+						has_war_with = ROOT
+					}
+				}
+				factor = 0
+			}
+		}
+		FROM = { country_event = lar_end_the_occupation.3 }
+	}
+}
+# Germany approves
+country_event = {
+	id = lar_end_the_occupation.2
+	title = lar_end_the_occupation.2.t
+	desc = lar_end_the_occupation.2.desc
+	picture = GFX_report_event_generic_military_parade
+
+	is_triggered_only = yes
+
+	option = {
+		name = lar_end_the_occupation.2.a 
+		ai_chance = {
+			factor = 50
+		}
+		hidden_effect = { news_event = { id = lar_news.4 days = 3 random_days = 5 } }
+		every_state = { #take over core french territory that is being held by Germany
+			limit = {
+				is_core_of = ROOT
+				NOT = { state = 28 } #Elsass-Lothringen ist deutsch!
+				NOT = { state = 735 } #Savoy is Italian
+				OR = {
+					is_controlled_by = FROM
+					CONTROLLER = {
+						is_in_faction_with = FROM 
+					}
+				}
+			}
+			ROOT = { transfer_state = PREV }
+		}
+		if = {
+			limit = {
+				NOT = { is_in_faction_with = FROM }
+			}
+			FROM = { add_to_faction = ROOT }
+		}
+		load_focus_tree = french_focus
+		unlock_national_focus = FRA_revive_the_national_bloc
+		unlock_national_focus = FRA_utilize_the_leagues
+		unlock_national_focus = FRA_national_regeneration
+		unlock_national_focus = FRA_diplomatic_freedom
+		unlock_national_focus = FRA_towards_a_new_europe
+	}
+}
+
+# Germany refuses
+country_event = {
+	id = lar_end_the_occupation.3
+	title = lar_end_the_occupation.3.t
+	desc = lar_end_the_occupation.3.desc
+	picture = GFX_report_event_german_reichstag_gathering
+
+	is_triggered_only = yes
+
+	option = {
+		name = lar_end_the_occupation.3.a #let's talk to Free France
+		ai_chance = {
+			factor = 50
+		}
+		random_other_country = {
+			limit = { 
+				original_tag = FRA 
+				has_government = democratic
+			}
+			country_event = lar_end_the_occupation.4
+			effect_tooltip = { annex_country = { target = VIC transfer_troops = yes } }
+		}
+	}
+	option = {
+		name = lar_end_the_occupation.3.b #fine, we'll do it ourselves
+		ai_chance = {
+			factor = 50
+		}
+		load_focus_tree = french_focus
+		unlock_national_focus = FRA_revive_the_national_bloc
+		unlock_national_focus = FRA_utilize_the_leagues
+		unlock_national_focus = FRA_national_regeneration
+		unlock_national_focus = FRA_diplomatic_freedom
+		unlock_national_focus = FRA_latin_entente
+	}
+}
+
+# Vichy wants to join after germany refuses to hand back territory
+country_event = {
+	id = lar_end_the_occupation.4
+	title = lar_end_the_occupation.4.t
+	desc = lar_end_the_occupation.4.desc
+	picture = GFX_report_event_degaulle_inspect_troops
+
+	is_triggered_only = yes
+
+	option = {
+		name = lar_end_the_occupation.4.a #agree
+		ai_chance = {
+			factor = 80
+		}
+		FROM = { country_event = lar_end_the_occupation.5 }
+		effect_tooltip = {
+			annex_country = { target = VIC transfer_troops = yes }
+		}
+	}
+	option = {
+		name = lar_end_the_occupation.4.b #refuse
+		ai_chance = {
+			factor = 20
+			modifier = {
+				FROM = { is_ai = no }
+				factor = 0
+			}
+		}
+		FROM = { country_event = lar_end_the_occupation.6 }
+	}
+}
+
+# Vichy joins Free France after germany refuses to hand back territory
+country_event = {
+	id = lar_end_the_occupation.5
+	title = lar_end_the_occupation.5.t
+	desc = lar_end_the_occupation.5.desc
+	picture = GFX_report_event_degaulle_inspect_troops
+
+	is_triggered_only = yes
+
+	immediate = {
+		hidden_effect = {
+			FROM = {
+				if = {
+					limit = {
+						is_ai = yes
+						VIC = { is_ai = no }
+					}
+					change_tag_from = VIC
+				}
+			}
+		}
+	}
+
+	option = {
+		name = lar_end_the_occupation.5.a #agree
+		ai_chance = {
+			factor = 80
+		}
+		FRA = {
+			annex_country = { target = VIC transfer_troops = yes }
+			load_focus_tree = french_focus
+			unlock_national_focus = FRA_revive_the_national_bloc
+			unlock_national_focus = FRA_laissez_faire
+			unlock_national_focus = FRA_protect_the_rights_of_man
+			unlock_national_focus = FRA_review_foreign_policy		
+		}
+	}
+}
+
+# Free France refuses, Vichy goes at it alone after all
+country_event = {
+	id = lar_end_the_occupation.6
+	title = lar_end_the_occupation.6.t
+	desc = lar_end_the_occupation.6.desc
+	picture = GFX_report_event_degaulle_churchill
+
+	is_triggered_only = yes
+
+	option = {
+		name = lar_end_the_occupation.6.a #agree
+		ai_chance = {
+			factor = 80
+		}
+		load_focus_tree = french_focus
+		unlock_national_focus = FRA_revive_the_national_bloc
+		unlock_national_focus = FRA_utilize_the_leagues
+		unlock_national_focus = FRA_national_regeneration
+		unlock_national_focus = FRA_diplomatic_freedom
+		unlock_national_focus = FRA_latin_entente
+	}
+}
+
+#    ##  #   #      ## ###  ##  ###  ### #   ### ### #   #      ##  ### #   # ### #       #   #  ##  ###  
+#   #  # #   #     #    #  #  # #  #  #  #    #   #   # #      #  #  #  #   #  #  #       #   # #  # #  # 
+#   #  # # # #      #   #  #### ###   #  #    #   #    #       #     #   # #   #  #       # # # #### ###  
+#   #  # # # #       #  #  #  # #  #  #  #    #   #    #       #  #  #   # #   #  #       # # # #  # #  # 
+###  ##   # #      ##   #  #  # ###  ### ### ###  #    #        ##  ###   #   ### ###      # #  #  # #  # 
+
+add_namespace = lar_low_stability_civil_war
+
+#communists start uprising
+country_event = {
+	id = lar_low_stability_civil_war.1
+	title = lar_low_stability_civil_war.1.t
+	desc = lar_low_stability_civil_war.1.desc
+	picture = GFX_report_event_spain_civil_war_volunteers_02
+
+	trigger = {
+		tag = FRA
+		OR = {
+			has_war = no
+			AND = {
+				SPR_scw_in_progress = yes
+				any_enemy_country = {
+					original_tag = SPR #civil war still fires if in intervention in Spain
+				}
+			}
+		}
+		has_stability < 0.25
+		not = { has_completed_focus = FRA_form_the_popular_front }
+	}
+	mean_time_to_happen = { days = 180 }
+	fire_only_once = yes
+	option = {
+		name = lar_low_stability_civil_war.1.a #agree
+		ai_chance = {
+			factor = 80
+		}
+		start_civil_war = {
+			ideology = communism
+			size = 0.5
+		}
+	}
+}
+
+#fascists start uprising
+country_event = {
+	id = lar_low_stability_civil_war.2
+	title = lar_low_stability_civil_war.2.t
+	desc = lar_low_stability_civil_war.2.desc
+	picture = GFX_report_event_spain_civil_war_soldiers
+
+	trigger = {
+		tag = FRA
+		OR = {
+			has_war = no
+			AND = {
+				SPR_scw_in_progress = yes
+				any_enemy_country = {
+					original_tag = SPR #civil war still fires if in intervention in Spain
+				}
+			}
+		}
+		has_stability < 0.25
+		has_completed_focus = FRA_form_the_popular_front
+		NOT = {
+			has_completed_focus = FRA_destroy_the_counter_revolution
+		}
+	}
+	mean_time_to_happen = { days = 180 }
+	fire_only_once = yes
+	option = {
+		name = lar_low_stability_civil_war.2.a #agree
+		ai_chance = {
+			factor = 80
+		}
+		start_civil_war = {
+			ideology = fascism
+			size = 0.5
+		}
+	}
+}
+
+#   #  ##  ###  # # ### ###       ## #  #  ##  ###  ###  ##   ##  ### 
+#   # #  # #  # # # #   #  #     #   #  # #  # #  #  #  #  # #    #   
+# # # #  # ###  ##  ##  ###       #  #### #  # ###   #  #### # ## ##  
+# # # #  # #  # # # #   #  #       # #  # #  # #  #  #  #  # #  # #   
+ # #   ##  #  # # # ### #  #     ##  #  #  ##  #  #  #  #  #  ##  ### 
+
+
+#events to notify player that they are having worker issues
+add_namespace = lar_worker_shortage
+
+#country switched to extensive conscription while on full employment
+country_event = {
+	id = lar_worker_shortage.1
+	title = lar_worker_shortage.1.t
+	desc = lar_worker_shortage.1.desc
+	picture = GFX_report_event_generic_factory
+
+	trigger = {
+		tag = FRA
+		has_idea = FRA_full_employment
+		not = { has_idea = FRA_worker_shortage }
+		OR = {
+			has_idea = extensive_conscription
+			has_idea = service_by_requirement
+			has_idea = all_adults_serve
+			has_idea = scraping_the_barrel
+		}
+	}
+	mean_time_to_happen = { days = 20 }
+	
+	immediate = {
+		hidden_effect = {
+			swap_ideas = {
+				remove_idea = FRA_full_employment
+				add_idea = FRA_worker_shortage
+			}
+		}
+	}
+
+	option = {
+		name = lar_worker_shortage.1.a #agree
+		ai_chance = {
+			factor = 80
+		}
+		effect_tooltip = { #actual effect in immediate so player can not avoid by waiting it out, tooltip here to tell player what is happening
+			swap_ideas = {
+				remove_idea = FRA_full_employment
+				add_idea = FRA_worker_shortage
+			}
+		}
+	}
+}
+
+#country demobilizes while having worker shortage
+country_event = {
+	id = lar_worker_shortage.2
+	title = lar_worker_shortage.2.t
+	desc = lar_worker_shortage.2.desc
+	picture = GFX_report_event_france_tank_production
+
+	trigger = {
+		tag = FRA
+		has_idea = FRA_worker_shortage
+		not = { has_idea = FRA_full_employment }
+		OR = {
+			has_idea = limited_conscription
+			has_idea = disarmed_nation
+			has_idea = volunteer_only
+		}
+	}
+	mean_time_to_happen = { days = 20 }
+	option = {
+		name = lar_worker_shortage.2.a #agree
+		ai_chance = {
+			factor = 80
+		}
+		swap_ideas = {
+			remove_idea = FRA_worker_shortage
+			add_idea = FRA_full_employment
+		}
+	}
+}
+
+ ##  ###  #   #  ##     ###  #  # ###   ##  #  #  ##   ## ###  ## 
+#  # #  # ## ## #       #  # #  # #  # #  # #  # #  # #   #   #   
+#### ###  # # #  #      ###  #  # ###  #    #### ####  #  ##   #  
+#  # #  # #   #   #     #    #  # #  # #  # #  # #  #   # #     # 
+#  # #  # #   # ##      #     ##  #  #  ##  #  # #  # ##  ### ##  
+
+add_namespace = lar_arms_purchases
+
+#intial event for US - France wants to buy weapons
+country_event = {
+	id = lar_arms_purchases.1
+	title = lar_arms_purchases.1.t
+	desc = lar_arms_purchases.1.desc
+	picture = GFX_report_event_generic_lend_lease
+	is_triggered_only = yes
+	option = {
+		name = lar_arms_purchases.1.a #agree
+		ai_chance = {
+			factor = 40
+		}
+		trigger = {
+			USA_can_sell_weapons_trigger = yes
+		}
+		FRA = {
+			country_event = lar_arms_purchases.2
+		}
+		army_experience = 10
+	}
+
+	option = {
+		name = lar_arms_purchases.1.b #refuse
+		ai_chance = {
+			factor = 60
+			modifier = {
+				FRA = { has_war = yes }
+				factor = 0.5
+			}
+		}
+		FRA = {
+			country_event = lar_arms_purchases.3
+		}
+	}
+}
+
+# rasponse event for France - country agrees
+country_event = {
+	id = lar_arms_purchases.2
+	title = lar_arms_purchases.2.t
+	desc = lar_arms_purchases.2.desc
+	picture = GFX_report_event_merchant_ship_01
+	is_triggered_only = yes
+	option = {
+		name = lar_arms_purchases.2.a #agree
+		ai_chance = {
+			factor = 100
+		}
+		set_country_flag = FRA_arms_purchases_permitted
+	}
+}
+#response event for France - US refuse
+country_event = {
+	id = lar_arms_purchases.3
+	title = lar_arms_purchases.3.t
+	desc = lar_arms_purchases.3.desc
+	picture = GFX_report_event_generic_read_write
+	is_triggered_only = yes
+	option = {
+		name = lar_arms_purchases.3.a #agree
+		ai_chance = {
+			factor = 80
+		}
+	}
+}
+
+#   #  ##  #   #  # #  # ### ### ### ###   ##     ###  ##       ## ###   ##  ### #  # 
+#   # #  # #   #  # ## #  #  #   #   #  # #        #  #  #     #   #  # #  #  #  ## # 
+ # #  #  # #   #  # # ##  #  ##  ##  ###   #       #  #  #      #  ###  ####  #  # ## 
+ # #  #  # #   #  # #  #  #  #   #   #  #   #      #  #  #       # #    #  #  #  #  # 
+  #    ##  ###  ##  #  #  #  ### ### #  # ##       #   ##      ##  #    #  # ### #  # 
+
+add_namespace = lar_france_volunteers
+
+#event for country - French volunteers have joined!
+country_event = {
+	id = lar_france_volunteers.1
+	title = lar_france_volunteers.1.t
+	desc = lar_france_volunteers.1.desc
+	picture = GFX_report_event_spain_civil_war_volunteers_01
+	immediate = {
+		if = {
+			limit = { has_government = fascism }
+			set_variable = { volunteer_strength = FRA.party_popularity@fascism }
+		}
+		else_if = {
+			limit = { has_government = communism }
+			set_variable = { volunteer_strength = FRA.party_popularity@communism }
+		}
+		else_if = {
+			limit = { has_government = democratic }
+			set_variable = { volunteer_strength = FRA.party_popularity@democratic }
+			multiply_variable = { volunteer_strength = FRA.war_support } #special modifier to reduce impact of democratic support
+		}
+		else_if = {
+			limit = { has_government = neutrality }
+			set_variable = { volunteer_strength = FRA.party_popularity@neutrality }
+		}
+		multiply_variable = { volunteer_strength = 1000 }
+	}
+	is_triggered_only = yes
+	option = {
+		name = lar_france_volunteers.1.a #agree
+		ai_chance = {
+			factor = 40
+		}
+		set_country_flag = FRA_has_received_volunteers
+		add_manpower = volunteer_strength
+	}
+}
+
+# volunteers return - hidden event
+country_event = {
+	id = lar_france_volunteers.2
+	hidden = yes
+	
+	trigger = {
+		original_tag = SPR
+		has_country_flag = FRA_has_received_volunteers
+		has_war = no
+	}
+	mean_time_to_happen = { days = 30 }
+	immediate = {
+		clr_country_flag = FRA_has_received_volunteers
+		FRA = { country_event = lar_france_volunteers.3 }
+	}
+	option = {}
+}  
+
+# volunteers return - event for France to accept them
+country_event = {
+	id = lar_france_volunteers.3
+	title = lar_france_volunteers.3.t
+	desc = lar_france_volunteers.3.desc
+	picture = GFX_report_event_saf_civil_war
+	is_triggered_only = yes
+	
+	option = {
+		name = lar_france_volunteers.3.a #agree
+		ai_chance = {
+			factor = 60
+		}
+		if = {
+			limit = {
+				FROM = {
+					has_government = fascism
+				}
+			}
+			add_popularity = { ideology = fascism popularity = 0.05 }
+			army_experience = 10
+		}
+		else_if = {
+			limit = {
+				FROM = {
+					has_government = communism
+				}
+			}
+			add_popularity = { ideology = communism popularity = 0.05 }
+			army_experience = 10
+		}
+		else_if = {
+			limit = {
+				FROM = {
+					has_government = democratic
+				}
+			}
+			add_popularity = { ideology = democratic popularity = 0.05 }
+			army_experience = 10
+		}
+		else_if = {
+			limit = {
+				FROM = {
+					has_government = neutrality
+				}
+			}
+			add_popularity = { ideology = neutrality popularity = 0.05 }
+			army_experience = 10
+		}
+	}
+
+	option = {
+		name = lar_france_volunteers.3.b #arefuse
+		ai_chance = {
+			factor = 40
+		}
+		if = {
+			limit = {
+				FROM = {
+					has_government = fascism
+				}
+			}
+			set_temp_variable = { stability_impact = party_popularity@fascism }
+			multiply_temp_variable = { stability_impact = 0.1 }
+			add_stability = stability_impact
+		}
+		else_if = {
+			limit = {
+				FROM = {
+					has_government = communism
+				}
+			}
+			set_temp_variable = { stability_impact = party_popularity@communism }
+			multiply_temp_variable = { stability_impact = 0.1 }
+			add_stability = stability_impact
+		}
+		else_if = {
+			limit = {
+				FROM = {
+					has_government = democratic
+				}
+			}
+			set_temp_variable = { stability_impact = party_popularity@democratic }
+			multiply_temp_variable = { stability_impact = 0.1 }
+			add_stability = stability_impact
+		}
+		else_if = {
+			limit = {
+				FROM = {
+					has_government = neutrality
+				}
+			}
+			set_temp_variable = { stability_impact = party_popularity@neutrality }
+			multiply_temp_variable = { stability_impact = 0.1 }
+			add_stability = stability_impact
+		}
+	}
+} 
+
+#  #  ##  #  #     ### #  # ### ### ###  #   # ### #  # ### ###  ##  #  #     ### #  #      ## ###   ##  ### #  # 
+## # #  # ## #      #  ## #  #  #   #  # #   # #   ## #  #   #  #  # ## #      #  ## #     #   #  # #  #  #  ## # 
+# ## #  # # ##      #  # ##  #  ##  ###   # #  ##  # ##  #   #  #  # # ##      #  # ##      #  ###  ####  #  # ## 
+#  # #  # #  #      #  #  #  #  #   #  #  # #  #   #  #  #   #  #  # #  #      #  #  #       # #    #  #  #  #  # 
+#  #  ##  #  #     ### #  #  #  ### #  #   #   ### #  #  #  ###  ##  #  #     ### #  #     ##  #    #  # ### #  # 
+
+add_namespace = lar_non_intervention
+
+#intial event France wants to propose non-intervention
+country_event = {
+	id = lar_non_intervention.1
+	title = lar_non_intervention.1.t
+	desc = lar_non_intervention.1.desc
+	picture = GFX_report_event_generic_conference
+	is_triggered_only = yes
+	option = {
+		name = lar_non_intervention.1.a #agree
+		ai_chance = {
+			factor = 80
+		}
+		set_country_flag = FRA_non_intervention_agreed
+		FRA = {
+			country_event = lar_non_intervention.2
+		}
+	}
+
+	option = {
+		name = lar_non_intervention.1.b #refuse
+		ai_chance = {
+			factor = 20
+		}
+		FRA = {
+			country_event = lar_non_intervention.3
+		}
+		set_country_flag = FRA_non_intervention_refused
+	}
+}
+
+# rasponse event for France - country agrees
+country_event = {
+	id = lar_non_intervention.2
+	title = lar_non_intervention.2.t
+	desc = lar_non_intervention.2.desc
+	picture = GFX_report_event_generic_sign_treaty1
+	is_triggered_only = yes
+	option = {
+		name = lar_non_intervention.2.a #agree
+		ai_chance = {
+			factor = 100
+		}
+		add_stability = 0.02
+		add_war_support = -0.01
+	}
+}
+#response event for France - country refuses
+country_event = {
+	id = lar_non_intervention.3
+	title = lar_non_intervention.3.t
+	desc = lar_non_intervention.3.desc
+	picture = GFX_report_event_generic_sign_treaty2
+	is_triggered_only = yes
+	option = {
+		name = lar_non_intervention.3.a #agree
+		ai_chance = {
+			factor = 80
+		}
+	}
+}
+
+ ##   ##  #   # #   # #  # #  # ###  ## ###      ## #  # ###  ###   ##  ###  ### 
+#  # #  # ## ## ## ## #  # ## #  #  #    #      #   #  # #  # #  # #  # #  #  #  
+#    #  # # # # # # # #  # # ##  #   #   #       #  #  # ###  ###  #  # ###   #  
+#  # #  # #   # #   # #  # #  #  #    #  #        # #  # #    #    #  # #  #  #  
+ ##   ##  #   # #   #  ##  #  # ### ##   #      ##   ##  #    #     ##  #  #  #  
+
+add_namespace = lar_communist_support
+
+country_event = {
+	id = lar_communist_support.1
+	hidden = yes
+	trigger = {
+		has_idea = FRA_communist_cooperation
+		communism > 0.15
+	}
+	fire_only_once = yes
+	immediate = {
+		swap_ideas = {
+			remove_idea = FRA_communist_cooperation
+			add_idea = FRA_communist_cooperation_2
+		}
+	}
+	mean_time_to_happen = { days = 5 }
+	option = {
+		
+	}
+}
+
+ ##  ###  ###  ###  ##  #       ###  ##       ##  #   # ### ###   ## ###  ##   ##     ### ### ###  ###  ### ###  ##  ###  #   # 
+#  # #  # #  # #   #  # #        #  #  #     #  # #   # #   #  # #   #   #  # #        #  #   #  # #  #  #   #  #  # #  #  # #  
+#### ###  ###  ##  #### #        #  #  #     #  #  # #  ##  ###   #  ##  ####  #       #  ##  ###  ###   #   #  #  # ###    #   
+#  # #    #    #   #  # #        #  #  #     #  #  # #  #   #  #   # #   #  #   #      #  #   #  # #  #  #   #  #  # #  #   #   
+#  # #    #    ### #  # ###      #   ##       ##    #   ### #  # ##  ### #  # ##       #  ### #  # #  # ###  #   ##  #  #   #   
+
+add_namespace = lar_appeal_to_overseas_territories
+
+country_event = {
+	id = lar_appeal_to_overseas_territories.1
+	hidden = yes
+	is_triggered_only = yes
+	immediate = {
+		random_list = {
+			85 = { country_event = lar_appeal_to_overseas_territories.2 } #indochina remains with Vichy
+			15 = { country_event = lar_appeal_to_overseas_territories.3 } #indochina switches sides
+		}
+		random_list = {
+			80 = { country_event = { id = lar_appeal_to_overseas_territories.4 days = 3 } } #syria remains with Vichy
+			20 = { country_event = { id = lar_appeal_to_overseas_territories.5 days = 3 } } #syria switches sides
+		}
+		random_list = {
+			80 = { country_event = { id = lar_appeal_to_overseas_territories.6 days = 8 } } #central africa remains with Vichy
+			20 = { country_event = { id = lar_appeal_to_overseas_territories.7 days = 8 } } #central africa switches sides
+		}
+		random_list = {
+			90 = { country_event = { id = lar_appeal_to_overseas_territories.8 days = 12 } } #western africa remains with Vichy
+			10 = { country_event = { id = lar_appeal_to_overseas_territories.9 days = 12 } } #western africa switches sides
+		}
+		random_list = {
+			70 = { country_event = { id = lar_appeal_to_overseas_territories.10 days = 16 } } #madagascar remains with Vichy
+			30 = { country_event = { id = lar_appeal_to_overseas_territories.11 days = 16 } } #madagascar switches sides
+		}
+		random_list = {
+			95 = { country_event = { id = lar_appeal_to_overseas_territories.12 days = 20 } } #north africa remains with Vichy
+			5 = { country_event = { id = lar_appeal_to_overseas_territories.13 days = 20 } } #north africa switches sides
+		}
+	}
+	
+	option = {
+		
+	}
+}
+
+# indochina remains with Vichy France
+country_event = {
+	id = lar_appeal_to_overseas_territories.2
+	title = lar_appeal_to_overseas_territories.2.t
+	desc = lar_appeal_to_overseas_territories.2.desc
+	picture = GFX_report_event_france_parade
+	is_triggered_only = yes
+	option = {
+		name = lar_appeal_to_overseas_territories.2.a #agree
+		ai_chance = {
+			factor = 100
+		}
+	}
+}
+#indochina switches sides
+country_event = {
+	id = lar_appeal_to_overseas_territories.3
+	title = lar_appeal_to_overseas_territories.3.t
+	desc = lar_appeal_to_overseas_territories.3.desc
+	picture = GFX_report_event_felix_eboue
+	is_triggered_only = yes
+	option = {
+		name = lar_appeal_to_overseas_territories.3.a #agree
+		ai_chance = {
+			factor = 80
+		}
+		VIC = { country_event = LaR_france_vichy_notification_events.2 }
+		FRA_transfer_indochina_effect = yes
+	}
+}
+
+# syria remains with Vichy France
+country_event = {
+	id = lar_appeal_to_overseas_territories.4
+	title = lar_appeal_to_overseas_territories.4.t
+	desc = lar_appeal_to_overseas_territories.4.desc
+	picture = GFX_report_event_france_parade
+	is_triggered_only = yes
+	option = {
+		name = lar_appeal_to_overseas_territories.2.a #agree
+		ai_chance = {
+			factor = 100
+		}
+	}
+}
+#syria switches sides
+country_event = {
+	id = lar_appeal_to_overseas_territories.5
+	title = lar_appeal_to_overseas_territories.5.t
+	desc = lar_appeal_to_overseas_territories.5.desc
+	picture = GFX_report_event_felix_eboue
+	is_triggered_only = yes
+	option = {
+		name = lar_appeal_to_overseas_territories.3.a #agree
+		ai_chance = {
+			factor = 80
+		}
+		VIC = { country_event = LaR_france_vichy_notification_events.1 }
+		FRA_transfer_syria_effect = yes
+	}
+}
+
+# central africa remains with Vichy France
+country_event = {
+	id = lar_appeal_to_overseas_territories.6
+	title = lar_appeal_to_overseas_territories.6.t
+	desc = lar_appeal_to_overseas_territories.6.desc
+	picture = GFX_report_event_france_parade
+	is_triggered_only = yes
+	option = {
+		name = lar_appeal_to_overseas_territories.6.a #agree
+		ai_chance = {
+			factor = 100
+		}
+	}
+}
+#central africa switches sides
+country_event = {
+	id = lar_appeal_to_overseas_territories.7
+	title = lar_appeal_to_overseas_territories.7.t
+	desc = lar_appeal_to_overseas_territories.7.desc
+	picture = GFX_report_event_felix_eboue
+	is_triggered_only = yes
+	option = {
+		name = lar_appeal_to_overseas_territories.3.a #agree
+		ai_chance = {
+			factor = 80
+		}
+		VIC = { country_event = LaR_france_vichy_notification_events.3 }
+		FRA_transfer_central_africa_effect = yes
+	}
+}
+# western africa remains with Vichy France
+country_event = {
+	id = lar_appeal_to_overseas_territories.8
+	title = lar_appeal_to_overseas_territories.8.t
+	desc = lar_appeal_to_overseas_territories.8.desc
+	picture = GFX_report_event_france_parade
+	is_triggered_only = yes
+	option = {
+		name = lar_appeal_to_overseas_territories.6.a #agree
+		ai_chance = {
+			factor = 100
+		}
+	}
+}
+#western africa switches sides
+country_event = {
+	id = lar_appeal_to_overseas_territories.9
+	title = lar_appeal_to_overseas_territories.9.t
+	desc = lar_appeal_to_overseas_territories.9.desc
+	picture = GFX_report_event_felix_eboue
+	is_triggered_only = yes
+	option = {
+		name = lar_appeal_to_overseas_territories.3.a #agree
+		ai_chance = {
+			factor = 80
+		}
+		VIC = { country_event = LaR_france_vichy_notification_events.4 }
+		FRA_transfer_western_africa_effect = yes
+	}
+}
+
+# madagascar remains with Vichy France
+country_event = {
+	id = lar_appeal_to_overseas_territories.10
+	title = lar_appeal_to_overseas_territories.10.t
+	desc = lar_appeal_to_overseas_territories.10.desc
+	picture = GFX_report_event_france_parade
+	is_triggered_only = yes
+	option = {
+		name = lar_appeal_to_overseas_territories.2.a #agree
+		ai_chance = {
+			factor = 100
+		}
+	}
+}
+#madagascar switches sides
+country_event = {
+	id = lar_appeal_to_overseas_territories.11
+	title = lar_appeal_to_overseas_territories.11.t
+	desc = lar_appeal_to_overseas_territories.11.desc
+	picture = GFX_report_event_felix_eboue
+	is_triggered_only = yes
+	option = {
+		name = lar_appeal_to_overseas_territories.3.a #agree
+		ai_chance = {
+			factor = 80
+		}
+		VIC = { country_event = LaR_france_vichy_notification_events.6 }
+		if = {
+			limit = {
+				MAD = {
+					exists = yes
+					is_subject = yes
+					OVERLORD = { original_tag = FRA }
+				}
+			}
+			puppet = MAD
+		}
+		else_if = {
+			limit = {
+				543 = { CONTROLLER = { original_tag = FRA } }
+			}
+			transfer_state = 543
+		}
+	}
+}
+# north africa remains with Vichy France
+country_event = {
+	id = lar_appeal_to_overseas_territories.12
+	title = lar_appeal_to_overseas_territories.12.t
+	desc = lar_appeal_to_overseas_territories.12.desc
+	picture = GFX_report_event_france_parade
+	is_triggered_only = yes
+	option = {
+		name = lar_appeal_to_overseas_territories.2.a #agree
+		ai_chance = {
+			factor = 100
+		}
+	}
+}
+#north africa switches sides
+country_event = {
+	id = lar_appeal_to_overseas_territories.13
+	title = lar_appeal_to_overseas_territories.13.t
+	desc = lar_appeal_to_overseas_territories.13.desc
+	picture = GFX_report_event_felix_eboue
+	is_triggered_only = yes
+	option = {
+		name = lar_appeal_to_overseas_territories.3.a #agree
+		ai_chance = {
+			factor = 80
+		}
+		VIC = { country_event = LaR_france_vichy_notification_events.5 }
+		FRA_transfer_north_africa_effect = yes
+	}
+}
+
+#   # ###  ##  #  # #   #     ###  ### #  # #  # ### ### ###  ##   ##  ### ###  ##  #  # 
+#   #  #  #  # #  #  # #      #  # #   #  # ## #  #  #    #  #  # #  #  #   #  #  # ## # 
+ # #   #  #    ####   #       ###  ##  #  # # ##  #  ##   #  #    ####  #   #  #  # # ## 
+ # #   #  #  # #  #   #       #  # #   #  # #  #  #  #    #  #  # #  #  #   #  #  # #  # 
+  #   ###  ##  #  #   #       #  # ###  ##  #  # ### #   ###  ##  #  #  #  ###  ##  #  # 
+
+add_namespace = lar_france_vichy_reunification
+
+# initial event - Vichy government asked to unify with FRA
+country_event = {
+	id = lar_france_vichy_reunification.1
+	title = lar_france_vichy_reunification.1.t
+	desc = lar_france_vichy_reunification.1.desc
+	picture = GFX_report_event_degaulle_inspect_troops
+	is_triggered_only = yes
+	option = {
+		name = lar_france_vichy_reunification.1.a #agree
+		ai_chance = {
+			factor = 80
+		}
+		if = {
+			limit = { FROM = { is_ai = no } }
+			custom_effect_tooltip = GAME_OVER_TT
+		}
+		FROM = {
+			country_event = lar_france_vichy_reunification.2
+		}
+	}
+
+	option = {
+		name = lar_france_vichy_reunification.1.b #refuse
+		ai_chance = {
+			factor = 20
+			modifier = {
+				FROM = {
+					is_ai = no #don't refuse the player
+				}
+				factor = 0
+			}
+			modifier = {
+				is_historical_focus_on = yes
+				factor = 0
+			}
+		}
+		FROM = { country_event = lar_france_vichy_reunification.3 }
+	}
+}
+
+#VIC agrees to unification - event for FRA
+country_event = {
+	id = lar_france_vichy_reunification.2
+	title = lar_france_vichy_reunification.2.t
+	desc = lar_france_vichy_reunification.2.desc
+	picture = GFX_report_event_degaulle_inspect_troops
+	is_triggered_only = yes
+	option = {
+		name = lar_france_vichy_reunification.2.a #agree
+		ai_chance = {
+			factor = 80
+		}
+		if = {
+			limit = {
+				FROM = { is_ai = no }
+				is_ai = yes
+			}
+			change_tag_from = FROM #if Vichy is played by player and FRA is AI, player gets to keep playing
+		}
+		
+		annex_country = { target = FROM transfer_troops = yes } 
+	}
+}
+
+#VIC refuses unification, FRA gains wargoal
+country_event = {
+	id = lar_france_vichy_reunification.3
+	title = lar_france_vichy_reunification.3.t
+	desc = lar_france_vichy_reunification.3.desc
+	picture = GFX_report_event_degaulle_churchill
+	is_triggered_only = yes
+	option = {
+		name = lar_france_vichy_reunification.3.a #agree
+		ai_chance = {
+			factor = 80
+		}
+		create_wargoal = {
+			type = annex_everything
+			target = FROM
+		}
+	}
+}
+
+add_namespace = lar_fra_inefficient_economy
+
+country_event = {
+	id = lar_fra_inefficient_economy.1
+	hidden = yes
+	is_triggered_only = yes
+	fire_only_once = yes
+	immediate = {
+		if = {
+			limit = { has_idea = FRA_inefficient_economy_2 }
+			swap_ideas = {
+				remove_idea = FRA_inefficient_economy_2
+				add_idea = FRA_inefficient_economy_1
+			}
+		}
+		else_if = {
+			limit = {
+				has_idea = FRA_inefficient_economy_1
+			}
+			remove_ideas = FRA_inefficient_economy_1
+		}
+	}
+	option = {
+		
+	}
+}
+
+add_namespace = lar_fra_reconnect_to_the_balkans
+
+#first event - balkan country asked if it wants to join the French faction
+country_event = {
+	id = lar_fra_reconnect_to_the_balkans.1
+	title = generic.5.t
+	desc = generic.5.d.a
+	picture = GFX_report_event_generic_read_write
+
+	is_triggered_only = yes
+	
+	immediate = {
+		hidden_effect = {
+			save_event_target_as = alliance_applicant
+			FROM = {
+				save_event_target_as = alliance_inviter
+			}
+		}
+	}
+
+	option = { #accept
+		name = generic.5.a	
+		ai_chance = {
+			factor = 100
+		}
+		var:FROM.faction_leader = { country_event = lar_fra_reconnect_to_the_balkans.2 }
+	}
+
+	option = { #refuse
+		name = generic.2.f
+		ai_chance = {
+			factor = 0
+		}
+		FROM = {
+			country_event = lar_fra_reconnect_to_the_balkans.3
+		}
+	}
+}
+#event 2 - country wants to join faction, ask faction leader?
+country_event = {
+	id = lar_fra_reconnect_to_the_balkans.2
+	title = generic.2.t
+	desc = generic.2.d.a
+	picture = GFX_report_event_generic_read_write
+
+	is_triggered_only = yes
+	immediate = {
+		hidden_effect = {
+			save_event_target_as = alliance_inviter
+			FROM = {
+				save_event_target_as = alliance_applicant
+			}
+		}
+	}
+
+	option = { #accept
+		name = generic.2.a	
+		ai_chance = {
+			factor = 100
+		}
+		FROM = { country_event = lar_fra_reconnect_to_the_balkans.4 }
+		FROM.FROM = { country_event = lar_fra_reconnect_to_the_balkans.4 }
+		add_to_faction = FROM
+	}
+
+	option = { #refuse
+		name = generic.2.f
+		ai_chance = {
+			factor = 0
+		}
+		FROM = {
+			country_event = lar_fra_reconnect_to_the_balkans.5
+		}
+		FROM.FROM = {
+			country_event = lar_fra_reconnect_to_the_balkans.5
+		}
+	}
+}
+
+#event 3 - country does not want to join faction at all
+country_event = {
+	id = lar_fra_reconnect_to_the_balkans.3
+	title = generic.7.t
+	desc = generic.7.d
+	picture = GFX_report_event_generic_read_write
+
+	is_triggered_only = yes
+	
+
+	option = { #accept
+		name = generic.7.a	
+		ai_chance = {
+			factor = 100
+		}
+	}
+}
+
+#event 4 - request accepted by faction leader
+country_event = {
+	id = lar_fra_reconnect_to_the_balkans.4
+	title = generic.6.t
+	desc = generic.6.d
+	picture = GFX_report_event_generic_read_write
+
+	is_triggered_only = yes
+	
+
+	option = { #accept
+		name = generic.3.a	
+		ai_chance = {
+			factor = 100
+		}
+	}
+}
+
+#event 4 - request refused by faction leader
+country_event = {
+	id = lar_fra_reconnect_to_the_balkans.5
+	title = generic.4.t
+	desc = generic.4.d
+	picture = GFX_report_event_generic_read_write
+
+	is_triggered_only = yes
+	
+
+	option = { #accept
+		name = generic.4.a	
+		ai_chance = {
+			factor = 100
+		}
+	}
+}
+
+add_namespace = lar_fra_join_the_ententes
+
+ ###  ##  ### #  #     ### #  # ###     ### #  # ### ### #  # ### ###  ## 
+   # #  #  #  ## #      #  #  # #       #   ## #  #  #   ## #  #  #   #   
+   # #  #  #  # ##      #  #### ##      ##  # ##  #  ##  # ##  #  ##   #  
+#  # #  #  #  #  #      #  #  # #       #   #  #  #  #   #  #  #  #     # 
+ ##   ##  ### #  #      #  #  # ###     ### #  #  #  ### #  #  #  ### ##  
+
+#first event - join the French faction?
+country_event = {
+	id = lar_fra_join_the_ententes.1
+	title = lar_fra_join_the_ententes.1.t
+	desc = lar_fra_join_the_ententes.1.desc
+	picture = GFX_report_event_generic_read_write
+
+	is_triggered_only = yes
+	
+	option = { #accept
+		name = lar_fra_join_the_ententes.1.a
+		ai_chance = {
+			factor = 100
+		}
+		FROM = { country_event = lar_fra_join_the_ententes.2 }
+	}
+
+	option = { #refuse
+		name = lar_fra_join_the_ententes.1.b
+		ai_chance = {
+			factor = 0
+		}
+		FROM = { country_event = lar_fra_join_the_ententes.3 }
+	}
+}
+
+#second event - Britain joins French faction, move them and all their subjects, fire event to independent nations in their faction
+country_event = {
+	id = lar_fra_join_the_ententes.2
+	title = lar_fra_join_the_ententes.2.t
+	desc = lar_fra_join_the_ententes.2.desc
+	picture = GFX_report_event_generic_read_write
+
+	is_triggered_only = yes
+	
+
+	option = { #accept
+		name = lar_fra_join_the_ententes.2.a
+		ai_chance = {
+			factor = 100
+		}
+		every_other_country = {
+			limit = {
+				is_in_faction_with = FROM
+				NOT = { tag = FROM } #countries are in a faction with themselves
+				is_subject = no
+			}
+			country_event = lar_fra_join_the_ententes.4
+		}
+		add_to_faction = FROM
+	}
+}
+
+#second event - country refuses
+country_event = {
+	id = lar_fra_join_the_ententes.3
+	title = lar_fra_join_the_ententes.3.t
+	desc = lar_fra_join_the_ententes.3.desc
+	picture = GFX_report_event_generic_read_write
+
+	is_triggered_only = yes
+	
+
+	option = { #accept
+		name = lar_fra_join_the_ententes.3.a
+		ai_chance = {
+			factor = 100
+		}
+	}
+}
+
+# event for independent countries in British faction - join france?
+country_event = {
+	id = lar_fra_join_the_ententes.4
+	title = lar_fra_join_the_ententes.1.t
+	desc = lar_fra_join_the_ententes.1.desc
+	picture = GFX_report_event_generic_read_write
+
+	is_triggered_only = yes
+	
+
+	option = { #accept
+		name = lar_fra_join_the_ententes.1.a
+		ai_chance = {
+			factor = 100
+		}
+		FROM = { country_event = lar_fra_join_the_ententes.5 }
+	}
+
+	option = { #refuse
+		name = lar_fra_join_the_ententes.1.b
+		ai_chance = {
+			factor = 0
+		}
+		FROM = { country_event = lar_fra_join_the_ententes.3 }
+	}
+}
+
+# event for france - non-british sovereign nation wants to join
+country_event = {
+	id = lar_fra_join_the_ententes.5
+	title = lar_fra_join_the_ententes.2.t
+	desc = lar_fra_join_the_ententes.2.desc
+	picture = GFX_report_event_generic_read_write
+
+	is_triggered_only = yes
+	
+	option = { #accept
+		name = lar_fra_join_the_ententes.2.a
+		ai_chance = {
+			factor = 100
+		}
+		add_to_faction = FROM
+	}
+}
+
+add_namespace = LaR_france_vichy_notification_events
+
+#  #  ##  ### ### ### ###  ##   ##  ### ###  ##  #  #     ### #   # ### #  # ###  ##     ###  ##  ###      #   # ###  ##  #  # #   # 
+## # #  #  #   #  #    #  #  # #  #  #   #  #  # ## #     #   #   # #   ## #  #  #       #   #  # #  #     #   #  #  #  # #  #  # #  
+# ## #  #  #   #  ##   #  #    ####  #   #  #  # # ##     ##   # #  ##  # ##  #   #      ##  #  # ###       # #   #  #    ####   #   
+#  # #  #  #   #  #    #  #  # #  #  #   #  #  # #  #     #    # #  #   #  #  #    #     #   #  # #  #      # #   #  #  # #  #   #   
+#  #  ##   #  ### #   ###  ##  #  #  #  ###  ##  #  #     ###   #   ### #  #  #  ##      #    ##  #  #       #   ###  ##  #  #   #   
+
+# event for Vichy - Syria has decided to side with de gaulle
+country_event = {
+	id = LaR_france_vichy_notification_events.1
+	title =  LaR_france_vichy_notification_events.1.t
+	desc =  LaR_france_vichy_notification_events.1.desc
+	picture = GFX_report_event_generic_read_write
+
+	is_triggered_only = yes
+	
+	option = { #accept
+		name =  LaR_france_vichy_notification_events.1.a
+		ai_chance = {
+			factor = 100
+		}
+		effect_tooltip = { FRA = { FRA_transfer_syria_effect = yes } }
+	}
+}
+
+# event for Vichy - Indochina has decided to side with de gaulle
+country_event = {
+	id = LaR_france_vichy_notification_events.2
+	title =  LaR_france_vichy_notification_events.2.t
+	desc =  LaR_france_vichy_notification_events.1.desc
+	picture = GFX_report_event_generic_read_write
+
+	is_triggered_only = yes
+	
+	option = { #accept
+		name =  LaR_france_vichy_notification_events.1.a
+		ai_chance = {
+			factor = 100
+		}
+		effect_tooltip = { FRA = { FRA_transfer_indochina_effect = yes } }
+	}
+}
+
+# event for Vichy - central africa has decided to side with de gaulle
+country_event = {
+	id = LaR_france_vichy_notification_events.3
+	title =  LaR_france_vichy_notification_events.3.t
+	desc =  LaR_france_vichy_notification_events.1.desc
+	picture = GFX_report_event_generic_read_write
+
+	is_triggered_only = yes
+	
+	option = { #accept
+		name =  LaR_france_vichy_notification_events.1.a
+		ai_chance = {
+			factor = 100
+		}
+		effect_tooltip = { FRA = { FRA_transfer_western_africa_effect = yes } }
+	}
+}
+
+# event for Vichy - west africa has decided to side with de gaulle
+country_event = {
+	id = LaR_france_vichy_notification_events.4
+	title =  LaR_france_vichy_notification_events.4.t
+	desc =  LaR_france_vichy_notification_events.1.desc
+	picture = GFX_report_event_generic_read_write
+
+	is_triggered_only = yes
+	
+	option = { #accept
+		name =  LaR_france_vichy_notification_events.1.a
+		ai_chance = {
+			factor = 100
+		}
+		effect_tooltip = { FRA = { FRA_transfer_central_africa_effect = yes } }
+	}
+}
+
+# event for Vichy - north_africa has decided to side with de gaulle
+country_event = {
+	id = LaR_france_vichy_notification_events.5
+	title =  LaR_france_vichy_notification_events.5.t
+	desc =  LaR_france_vichy_notification_events.1.desc
+	picture = GFX_report_event_generic_read_write
+
+	is_triggered_only = yes
+	
+	option = { #accept
+		name =  LaR_france_vichy_notification_events.1.a
+		ai_chance = {
+			factor = 100
+		}
+		effect_tooltip = { FRA = { FRA_transfer_north_africa_effect = yes } }
+	}
+}
+
+# event for Vichy - madagascar has decided to side with de gaulle
+country_event = {
+	id = LaR_france_vichy_notification_events.6
+	title =  LaR_france_vichy_notification_events.6.t
+	desc =  LaR_france_vichy_notification_events.1.desc
+	picture = GFX_report_event_generic_read_write
+
+	is_triggered_only = yes
+	
+	option = { #accept
+		name =  LaR_france_vichy_notification_events.1.a
+		ai_chance = {
+			factor = 100
+		}
+		effect_tooltip = { FRA = { transfer_state = 543 } }
+	}
+}
+
+# event for Vichy - coup in Syria
+country_event = {
+	id = LaR_france_vichy_notification_events.7
+	title =  LaR_france_vichy_notification_events.7.t
+	desc =  LaR_france_vichy_notification_events.7.desc
+	picture = GFX_report_event_generic_read_write
+
+	is_triggered_only = yes
+	
+	option = { #accept
+		name =  LaR_france_vichy_notification_events.7.a
+		ai_chance = {
+			factor = 100
+		}
+		effect_tooltip = { FRA = { FRA_transfer_syria_effect = yes } }
+	}
+}
+
+# event for Vichy - coup in indochina
+country_event = {
+	id = LaR_france_vichy_notification_events.8
+	title =  LaR_france_vichy_notification_events.8.t
+	desc =  LaR_france_vichy_notification_events.7.desc
+	picture = GFX_report_event_generic_read_write
+
+	is_triggered_only = yes
+	
+	option = { #accept
+		name =  LaR_france_vichy_notification_events.7.a
+		ai_chance = {
+			factor = 100
+		}
+		effect_tooltip = { FRA = { FRA_transfer_indochina_effect = yes } }
+	}
+}
+
+# event for Vichy - coup in central_africa
+country_event = {
+	id = LaR_france_vichy_notification_events.9
+	title =  LaR_france_vichy_notification_events.9.t
+	desc =  LaR_france_vichy_notification_events.7.desc
+	picture = GFX_report_event_generic_read_write
+
+	is_triggered_only = yes
+	
+	option = { #accept
+		name =  LaR_france_vichy_notification_events.7.a
+		ai_chance = {
+			factor = 100
+		}
+		effect_tooltip = { FRA = { FRA_transfer_central_africa_effect = yes } }
+	}
+}
+
+# event for Vichy - coup in west_africa
+country_event = {
+	id = LaR_france_vichy_notification_events.10
+	title =  LaR_france_vichy_notification_events.10.t
+	desc =  LaR_france_vichy_notification_events.7.desc
+	picture = GFX_report_event_generic_read_write
+
+	is_triggered_only = yes
+	
+	option = { #accept
+		name =  LaR_france_vichy_notification_events.7.a
+		ai_chance = {
+			factor = 100
+		}
+		effect_tooltip = { FRA = { FRA_transfer_western_africa_effect = yes } }
+	}
+}
+
+# event for Vichy - coup in north_africa
+country_event = {
+	id = LaR_france_vichy_notification_events.11
+	title =  LaR_france_vichy_notification_events.11.t
+	desc =  LaR_france_vichy_notification_events.7.desc
+	picture = GFX_report_event_generic_read_write
+
+	is_triggered_only = yes
+	
+	option = { #accept
+		name =  LaR_france_vichy_notification_events.7.a
+		ai_chance = {
+			factor = 100
+		}
+		effect_tooltip = { FRA = { FRA_transfer_north_africa_effect = yes } }
+	}
+}
+
+# event for Vichy - coup in Madagascar
+country_event = {
+	id = LaR_france_vichy_notification_events.12
+	title =  LaR_france_vichy_notification_events.12.t
+	desc =  LaR_france_vichy_notification_events.7.desc
+	picture = GFX_report_event_generic_read_write
+
+	is_triggered_only = yes
+	
+	option = { #accept
+		name =  LaR_france_vichy_notification_events.7.a
+		ai_chance = {
+			factor = 100
+		}
+		effect_tooltip = { FRA = { transfer_state = 543 } }
+	}
+}

--- a/events/LaR_France.txt
+++ b/events/LaR_France.txt
@@ -3642,28 +3642,28 @@ country_event = {
 	is_triggered_only = yes
 	immediate = {
 		random_list = {
-			85 = { country_event = lar_appeal_to_overseas_territories.2 } #indochina remains with Vichy
-			15 = { country_event = lar_appeal_to_overseas_territories.3 } #indochina switches sides
+			100 = { country_event = lar_appeal_to_overseas_territories.2 } #indochina remains with Vichy
+			0 = { country_event = lar_appeal_to_overseas_territories.3 } #indochina switches sides
 		}
 		random_list = {
-			80 = { country_event = { id = lar_appeal_to_overseas_territories.4 days = 3 } } #syria remains with Vichy
-			20 = { country_event = { id = lar_appeal_to_overseas_territories.5 days = 3 } } #syria switches sides
+			80 = { country_event = { id = lar_appeal_to_overseas_territories.4 days = 1 } } #syria remains with Vichy
+			20 = { country_event = { id = lar_appeal_to_overseas_territories.5 days = 1 } } #syria switches sides
 		}
 		random_list = {
-			80 = { country_event = { id = lar_appeal_to_overseas_territories.6 days = 8 } } #central africa remains with Vichy
-			20 = { country_event = { id = lar_appeal_to_overseas_territories.7 days = 8 } } #central africa switches sides
+			0 = { country_event = { id = lar_appeal_to_overseas_territories.6 days = 2 } } #central africa remains with Vichy
+			100 = { country_event = { id = lar_appeal_to_overseas_territories.7 days = 2 } } #central africa switches sides
 		}
 		random_list = {
-			90 = { country_event = { id = lar_appeal_to_overseas_territories.8 days = 12 } } #western africa remains with Vichy
-			10 = { country_event = { id = lar_appeal_to_overseas_territories.9 days = 12 } } #western africa switches sides
+			80 = { country_event = { id = lar_appeal_to_overseas_territories.8 days = 3 } } #western africa remains with Vichy
+			20 = { country_event = { id = lar_appeal_to_overseas_territories.9 days = 3 } } #western africa switches sides
 		}
 		random_list = {
-			70 = { country_event = { id = lar_appeal_to_overseas_territories.10 days = 16 } } #madagascar remains with Vichy
-			30 = { country_event = { id = lar_appeal_to_overseas_territories.11 days = 16 } } #madagascar switches sides
+			80 = { country_event = { id = lar_appeal_to_overseas_territories.10 days = 4 } } #madagascar remains with Vichy
+			20 = { country_event = { id = lar_appeal_to_overseas_territories.11 days = 4 } } #madagascar switches sides
 		}
 		random_list = {
-			95 = { country_event = { id = lar_appeal_to_overseas_territories.12 days = 20 } } #north africa remains with Vichy
-			5 = { country_event = { id = lar_appeal_to_overseas_territories.13 days = 20 } } #north africa switches sides
+			100 = { country_event = { id = lar_appeal_to_overseas_territories.12 days = 5 } } #north africa remains with Vichy
+			0 = { country_event = { id = lar_appeal_to_overseas_territories.13 days = 5 } } #north africa switches sides
 		}
 	}
 	


### PR DESCRIPTION
- Made intervene in Vichy decisions available to UK
- Added ai_will_do to some decisions (intervene in SCW and Vichy France decisions)
- Made intervene in Vichy available for UK
- set and check for global flags, so the Vichy french decisions can only be taken once, by either UK or France.
- Changed randomness and event delay for the event spawning from the Free.France Focus Appeal to Oversees.
- Removed chance that Indochina or North Africa ever would flip to Free France, in return increased Central Africa to 100% chance flipping to Free France.
- Having some randomness with the less important areas of West Africa, Syria and Madagascar.
- Reduced the delay per event to be only 1 day apart. On speed 2 this should be still enough time to comprehend those events.