### PR TITLE
Made Italian Claims on France Focus more available and powerful

### DIFF
--- a/common/national_focus/italy.txt
+++ b/common/national_focus/italy.txt
@@ -2494,10 +2494,24 @@ focus_tree = {
 				any_other_country = {
 					original_tag = FRA
 					has_government = fascism
-					owns_state = 735
-					controls_state = 735
-					owns_state = 1
-					controls_state = 1
+					OR = {
+						AND = {
+							owns_state = 735
+							controls_state = 735 #Savoy
+						}
+						AND = {
+							owns_state = 1
+							controls_state = 1 #Corsica
+						}
+						AND = {
+							owns_state = 21
+							controls_state = 21 #Provence
+						}
+						AND = {
+							owns_state = 32
+							controls_state = 32 #Alps
+						}
+					}
 				}
 			}
 		}
@@ -2525,7 +2539,7 @@ focus_tree = {
 		}	
 		completion_reward = {
 			if = {
-				limit = { 
+				limit = {
 					any_other_country = {
 						original_tag = FRA
 						has_government = fascism
@@ -2535,7 +2549,7 @@ focus_tree = {
 				set_global_flag = ITA_claims_on_france_735
 			}
 			if = {
-				limit = { 
+				limit = {
 					any_other_country = {
 						original_tag = FRA
 						has_government = fascism
@@ -2543,6 +2557,26 @@ focus_tree = {
 					}
 				}
 				set_global_flag = ITA_claims_on_france_1
+			}
+			if = {
+				limit = {
+					any_other_country = {
+						original_tag = FRA
+						has_government = fascism
+						owns_state = 21
+					}
+				}
+				set_global_flag = ITA_claims_on_france_21
+			}
+			if = {
+				limit = {
+					any_other_country = {
+						original_tag = FRA
+						has_government = fascism
+						owns_state = 32
+					}
+				}
+				set_global_flag = ITA_claims_on_france_32
 			}
 
 			GER = { country_event = germany.104 }			

--- a/events/France.txt
+++ b/events/France.txt
@@ -1858,6 +1858,14 @@ country_event = {
 				limit = { has_global_flag = ITA_claims_on_france_1 }
 				ITA = { transfer_state = 1 }
 			}
+			if = {
+				limit = { has_global_flag = ITA_claims_on_france_21 }
+				ITA = { transfer_state = 21 }
+			}
+			if = {
+				limit = { has_global_flag = ITA_claims_on_france_32 }
+				ITA = { transfer_state = 32 }
+			}
 		}
 
 		if = {

--- a/events/Germany.txt
+++ b/events/Germany.txt
@@ -4689,6 +4689,8 @@ country_event = {
 		name = germany.104.b
 		trigger = {
 			NOT = { has_global_flag = ITA_claims_on_france_735 }
+			NOT = { has_global_flag = ITA_claims_on_france_21 }
+			NOT = { has_global_flag = ITA_claims_on_france_32 }
 			has_global_flag = ITA_claims_on_france_1
 		}
 		random_other_country = {
@@ -4706,7 +4708,11 @@ country_event = {
 		ai_chance = { factor = 70 }
 		name = germany.104.c
 		trigger = {
-			has_global_flag = ITA_claims_on_france_735
+			OR = {
+				has_global_flag = ITA_claims_on_france_735
+				has_global_flag = ITA_claims_on_france_21
+				has_global_flag = ITA_claims_on_france_32
+			}
 			NOT = { has_global_flag = ITA_claims_on_france_1 }
 		}
 		random_other_country = {
@@ -4724,7 +4730,11 @@ country_event = {
 		ai_chance = { factor = 20 }
 		name = germany.104.e
 		trigger = {
-			has_global_flag = ITA_claims_on_france_735
+			OR = {
+				has_global_flag = ITA_claims_on_france_735
+				has_global_flag = ITA_claims_on_france_21
+				has_global_flag = ITA_claims_on_france_32
+			}
 			has_global_flag = ITA_claims_on_france_1
 		}
 		random_other_country = {

--- a/events/Italy.txt
+++ b/events/Italy.txt
@@ -1,0 +1,613 @@
+﻿###########################
+# Italian Events
+###########################
+
+add_namespace = italy
+
+# Albania Yields
+country_event = {
+	id = italy.1
+	title = italy.1.t
+	desc = italy.1.d
+	picture = GFX_report_event_royal_parade
+	
+	is_triggered_only = yes
+	
+	option = {
+		name = italy.1.a
+		annex_country = { target = ALB }
+		add_named_threat = { threat = 2 name = ITA_albania_war_goal }
+		USA = {
+			set_country_flag = { flag = USA_albania_window days = 60 value = 1 }
+		}
+		hidden_effect = {
+			country_event = { days = 1 id = news.22 }
+		}
+	}
+}
+
+# Zog Rejects Ultimatum
+country_event = {
+	id = italy.2
+	title = italy.2.t
+	desc = italy.2.d
+	picture = GFX_report_event_albanian_partisans
+	
+	is_triggered_only = yes
+	
+	option = {
+		name = italy.2.a
+		create_wargoal = {
+			type = take_state_focus
+			target = ALB
+			generator = { 44 }
+		}
+		hidden_effect = {
+			country_event = { days = 1 id = news.23 }
+		}
+	}
+}
+
+# Albania Receives Ultimatum
+country_event = {
+	id = italy.3
+	title = italy.3.t
+	desc = italy.3.d
+	picture = GFX_report_event_albanian_king_zog
+	
+	is_triggered_only = yes
+	
+	option = { # Yield
+		name = italy.3.a
+		ai_chance = {
+			base = 40
+			modifier = {
+				factor = 0
+				OR = {			
+					any_other_country = {
+						OR = {
+							is_major = yes
+							tag = YUG
+						}
+						NOT = { tag = ITA }
+						OR = {
+							has_guaranteed = ROOT
+							is_in_faction_with = ROOT
+						}
+					}
+					AND = {
+						is_subject = yes
+						NOT = { is_subject_of = ITA }
+					}
+				}
+			}
+			modifier = {
+				factor = 0.5
+				OR = {
+					has_government = communism
+					has_government = fascism #glorious Albania will never yield!
+				}
+			}
+			modifier = {
+				factor = 5
+				is_subject_of = ITA
+			}
+		}
+		ITA = {
+			country_event = { days = 1 id = italy.1 }
+		}
+		custom_effect_tooltip = GAME_OVER_TT
+	}
+	option = { # Resist
+		name = italy.3.b
+		ai_chance = {
+			factor = 20 
+			modifier = {
+				factor = 0
+				OR = {
+					AND = {
+						is_in_faction_with = ITA
+						ITA = { is_faction_leader = yes }
+					}
+					AND = {
+						any_other_country = {
+							OR = {
+								is_major = yes
+								tag = YUG
+							}
+							NOT = { tag = ITA }
+							OR = {
+								has_guaranteed = ROOT
+								is_in_faction_with = ROOT
+							}
+						}
+						is_historical_focus_on = yes
+					}
+					AND = {
+						is_in_faction = no 
+						NOT = {
+							any_other_country = {
+								NOT = { tag = ITA }
+								has_guaranteed = ROOT
+							} 
+						}
+					}
+				}
+			}
+			modifier = {
+				add = 100
+				is_in_faction = yes
+				NOT = { is_in_faction_with = ITA }
+			}
+			modifier = {
+				add = 100
+				is_subject = yes
+				NOT = { is_subject_of = ITA }
+			}
+		}
+		ITA = {
+			effect_tooltip = {
+				create_wargoal = {
+					type = take_state_focus
+					target = ALB
+					generator = { 44 }
+				}
+			}
+			country_event = { days = 1 id = italy.2 }
+		}
+	}
+}
+
+# Extension of the Vallo Alpino
+country_event = {
+	id = italy.4
+	title = italy.4.t
+	desc = italy.4.d
+	picture = GFX_report_event_bunker_01
+	
+	is_triggered_only = yes
+	
+	option = {
+		name = italy.4.a
+		158 = {
+			add_building_construction = {
+				type = bunker
+				province = 11891
+				level = 3
+			}
+			add_building_construction = {
+				type = bunker
+				province = 11721
+				level = 3
+			}
+		
+			add_building_construction = {
+				type = bunker
+				province = 9738
+				level = 3
+			}
+		}
+		160 = {
+			add_building_construction = {
+				type = bunker
+				province = 3657
+				level = 3
+			}
+			add_building_construction = {
+				type = bunker
+				province = 9613
+				level = 3
+			}
+			add_building_construction = {
+				type = bunker
+				province = 11595
+				level = 3
+			}
+		}
+	}
+}
+
+
+# Italian-German Treaty (Germans)
+country_event = {
+	id = italy.5
+	title = italy.5.t
+	desc = italy.5.d
+	picture = GFX_report_event_german_italian_pact
+	
+	is_triggered_only = yes
+	
+	option = {
+		name = italy.5.a	#sounds good
+		ITA = {
+			country_event = { days = 1 id = italy.6 }
+		}
+		# REVISIT Balance research bonus, also in event below
+		add_tech_bonus = {
+			bonus = 1.0
+			uses = 1
+			technology = tech_mountaineers2
+		}
+		add_tech_bonus = {
+			bonus = 1.0
+			uses = 2
+			category = naval_doctrine
+		}
+	}
+	
+	option = {
+		name = italy.5.b	#no way 
+		ai_chance = { factor = 0 }
+		add_political_power = -10
+		ITA = {
+			country_event = { days = 1 id = italy.7 }
+		}
+	}
+}
+
+# Germans Accept Italian-German Treaty
+country_event = {
+	id = italy.6
+	title = italy.6.t
+	desc = italy.6.d
+	picture = GFX_report_event_physics_lab_01
+
+	is_triggered_only = yes
+	
+	option = {
+		name = italy.6.a
+		# REVISIT Balance research bonus
+		add_tech_bonus = {
+			name = synth_bonus
+			bonus = 1.0
+			uses = 1
+			category = synth_resources
+		}
+		add_tech_bonus = {
+			name = armor_bonus
+			bonus = 1.0
+			uses = 2
+			category = armor
+		}
+		ITA = {
+			add_opinion_modifier = { target = GER modifier = ger_ita_tech_treaty }
+		}
+	}
+}
+
+# Germans Reject Italian-German Treaty
+country_event = {
+	id = italy.7
+	title = italy.7.t
+	desc = italy.7.d
+	picture = GFX_report_event_physics_lab_01
+
+	is_triggered_only = yes
+	
+	option = {
+		name = italy.7.a
+		ITA = {
+			add_opinion_modifier = { target = GER modifier = ger_ita_tech_treaty_rejected }
+		}
+	}
+}
+
+# French national focus - French asks Italy to join french faction
+country_event = {
+	id = italy.8
+	title = italy.8.t
+	desc = italy.8.d
+	picture = GFX_report_event_german_parade_paris
+
+	is_triggered_only = yes
+	
+	option = {
+		name = italy.8.a
+		FRA = {
+			if = {
+				limit = { is_in_faction = no }
+				set_rule = { can_create_factions = yes }
+				create_faction = "domination_francaise"
+			}
+		}
+		FRA = {	add_to_faction = ITA }
+		ITA = {
+			add_ai_strategy = {
+				type = alliance
+				id = "FRA"
+				value = 200
+			}
+		}
+		FRA = {
+			add_ai_strategy = {
+				type = alliance
+				id = "ITA"
+				value = 200
+			}
+		}
+		hidden_effect = {
+			news_event = { hours = 6 id = news.181 }
+		}
+	}
+	option = {
+		name = italy.8.b
+		ai_chance = { factor = 0 }
+		FRA = {
+			add_opinion_modifier = { target = ITA modifier = ITA_FRA_woo_italy_reject }
+		}	
+		hidden_effect = {
+			news_event = { hours = 6 id = news.183 }
+		}
+	}
+}
+
+# Request Balearic Islands from Spain
+country_event = {
+	id = italy.9
+	title = italy.9.t
+	desc = italy.9.d
+	picture = GFX_report_event_merchant_ship_01
+
+	is_triggered_only = yes
+	
+	option = {
+		name = italy.9.a
+		ITA = { country_event = { id = italy.10 } }
+		effect_tooltip = {
+			ITA = { transfer_state = 177 }
+			remove_opinion_modifier = { target = ITA modifier = ita_supported_spain_civil_war }
+		}
+
+		hidden_effect = {
+			news_event = { id = news.190 }
+		}
+	}
+	option = {
+		name = italy.9.b
+		ai_chance = { factor = 0 }
+		ITA = { country_event = { id = italy.11 } }
+		effect_tooltip = {
+			ITA = { add_state_claim = 177 }
+		}
+	}
+}
+
+# Spain Gives Up Balearic Islands
+country_event = {
+	id = italy.10
+	title = italy.10.t
+	desc = italy.10.d
+	picture = GFX_report_event_merchant_ship_01
+
+	is_triggered_only = yes
+	
+	option = {
+		name = italy.10.a
+		ITA = { transfer_state = 177 }
+		remove_opinion_modifier = { target = ITA modifier = ita_supported_spain_civil_war }
+	}
+}
+
+# Spain Refuses to Give Up Islands
+country_event = {
+	id = italy.11
+	title = italy.11.t
+	desc = italy.11.d
+	picture = GFX_report_event_merchant_ship_01
+
+	is_triggered_only = yes
+	
+	option = {
+		name = italy.11.a
+		ITA = { add_state_claim = 177 }
+	}
+}
+
+# Germany want to claim Slovenia from Yugoslavia
+country_event = {
+	id = italy.12
+	title = italy.12.t
+	desc = italy.12.d
+	picture = GFX_report_event_hitler_croatia_handshake
+
+	is_triggered_only = yes
+	
+	option = {
+		ai_chance = {
+			factor = 33
+			modifier = {
+				factor = 3
+				has_army_size = { size > 75 }
+			}
+		}
+		name = italy.12.a
+		ITA = {
+			add_political_power = -100
+			if = { limit = { is_faction_leader = yes }
+				add_to_faction = YUG
+				YUG = {
+					add_ai_strategy = {
+						type = alliance
+						id = "ITA"
+						value = 200
+					}
+				}
+			}
+			if = {
+				limit = { 
+					OR = {
+						AND = {
+							is_faction_leader = no
+							is_in_faction = yes
+						}
+						is_in_faction = no
+					}
+				}
+				create_faction = italy_empire_faction
+				add_to_faction = YUG
+				YUG = {
+					add_ai_strategy = {
+						type = alliance
+						id = "ITA"
+						value = 200
+					}
+				}
+			}			
+		}
+		GER = { country_event = { id = germany.96 hours = 6 } }
+		YUG = { country_event = { id = yugoslavia.6 hours = 6 } }
+	}	
+	option = {
+		ai_chance = {
+			factor = 100
+		}	
+		name = italy.12.b
+		YUG = {
+			add_opinion_modifier = { target = ITA modifier = western_betrayal }
+			country_event = { id = yugoslavia.5 hours = 6 }
+		}
+	}
+}
+
+# Italy (First Ljubljana Award) from german focus
+country_event = {
+	id = italy.13
+	title = italy.13.t
+	desc = { 
+		text = italy.13.d_dalmatia_montenegro
+		trigger = {
+			has_completed_focus = ITA_slovenia_dalmatia_claims
+			owns_state = 44
+		}
+	}
+	desc = { 
+		text = italy.13.d_dalmatia
+		trigger = {
+			has_completed_focus = ITA_slovenia_dalmatia_claims
+			NOT = { owns_state = 44 }
+		}
+	}
+	desc = { 
+		text = italy.13.d_montenegro
+		trigger = {
+			NOT = { has_completed_focus = ITA_slovenia_dalmatia_claims }
+			owns_state = 44
+		}
+	}
+ 
+	picture = GFX_report_event_vienna_award_negotiations
+	
+	is_triggered_only = yes
+	
+	option = {
+		name = italy.13.a
+		if = {
+			limit = { has_completed_focus = ITA_slovenia_dalmatia_claims }
+			ITA = { transfer_state = 103 }
+		}
+		if = {
+			limit = { owns_state = 44 }
+			ITA = { transfer_state = 105 }
+		}
+		if = {
+			limit = { owns_state = 44 }
+			ITA = { transfer_state = 802 }
+		}
+	}
+}
+
+
+# Italy Germany rejects demands for Vichy territory
+country_event = {
+	id = italy.14
+	title = italy.14.t
+	desc = italy.14.d
+ 
+	picture = GFX_report_event_generic_sign_treaty1
+	
+	is_triggered_only = yes
+	
+	option = {
+		ai_chance = { factor = 25 }
+		name = italy.14.a
+		GER = { 
+			remove_from_faction = ITA 
+			country_event = germany.105
+		}
+	}
+
+	option = {
+		ai_chance = { factor = 75 }
+		name = italy.14.b
+
+	}
+}
+
+
+# Italy Germany accepts demands for Vichy territory
+country_event = {
+	id = italy.15
+	title = italy.15.t
+	desc = { 
+		text = italy.15.d
+		trigger = {
+			OR = {
+				has_global_flag = ITA_claims_on_france_735
+				has_global_flag = ITA_claims_on_france_21
+				has_global_flag = ITA_claims_on_france_32
+			}
+			has_global_flag = ITA_claims_on_france_1
+		}
+	}
+	desc = { 
+		text = italy.15.d_Corsica
+		trigger = {
+			NOT = { has_global_flag = ITA_claims_on_france_735 }
+			NOT = { has_global_flag = ITA_claims_on_france_21 }
+			NOT = { has_global_flag = ITA_claims_on_france_32 }
+			has_global_flag = ITA_claims_on_france_1
+		}
+	}
+ 
+	picture = GFX_report_event_generic_sign_treaty1
+	
+	is_triggered_only = yes
+	
+	option = {
+		name = italy.15.a
+		if = {
+			limit = { has_global_flag = ITA_claims_on_france_735 }
+			ITA = { transfer_state = 735 }
+		}
+		if = {
+			limit = { has_global_flag = ITA_claims_on_france_1 }
+			ITA = { transfer_state = 1 }
+		}
+		if = {
+			limit = { has_global_flag = ITA_claims_on_france_21 }
+			ITA = { transfer_state = 21 }
+		}
+		if = {
+			limit = { has_global_flag = ITA_claims_on_france_32 }
+			ITA = { transfer_state = 32 }
+		}
+	}
+}
+
+# Italy Germany accepts some of demands for Vichy territory
+country_event = {
+	id = italy.16
+	title = italy.16.t
+	desc = italy.16.d
+ 
+	picture = GFX_report_event_generic_sign_treaty1
+	
+	is_triggered_only = yes
+	
+	option = {
+		name = italy.16.a
+
+		transfer_state = 735
+	}
+}
+


### PR DESCRIPTION
Made Italian "Claims on France" Focus more available, meaning:
If any of the states of Corsica, Savoy, Provence or Alps is owned by Vichy, Italy can pick that focus.

Changed events to transfer territory up to the Rhône, including states Provence and Alps, like usually gets transferred.
With the change of immediate Vichy creation, now Italy either have to conquer those territories before, or do a 70 day focus to get those territories