### PR TITLE
[NC] Added small additional condition to prevent early BUL historical claims decision

### DIFF
--- a/common/decisions/BUL.txt
+++ b/common/decisions/BUL.txt
@@ -8306,8 +8306,13 @@ BUL_negotiate_claims_in_the_balkans = {
 					option = BUL_MP_1
 				}
 				GRE = {
-					has_capitulated = no
-					surrender_progress < 0.9
+					OR = {
+						AND = {
+							surrender_progress < 0.95
+							has_capitulated = no
+						}
+						controls_state = 184
+					}
 				}
 			}
 		}


### PR DESCRIPTION
Added small additional condition to prevent early BUL historical claims decision
As long as Greece controls Thracia, Bulgaria won't ask for it's claims.
To prevent weirdness, that Thracia gets claimed by Bulgaria, but not transferred if Germany accepts.