### PR TITLE
Slightly tweaked Japanese Indonesian Oil decision

### DIFF
--- a/common/decisions/JAP.txt
+++ b/common/decisions/JAP.txt
@@ -2672,7 +2672,7 @@ prospect_for_resources = {
 						tag = ROOT
 						is_subject_of = ROOT
 					}
-					has_full_control_of_state = PREV
+					#has_full_control_of_state = PREV
 				}
 			}
 			672 = {
@@ -2681,7 +2681,7 @@ prospect_for_resources = {
 						tag = ROOT
 						is_subject_of = ROOT
 					}
-					has_full_control_of_state = PREV
+					#has_full_control_of_state = PREV
 				}
 			}
 			334 = {
@@ -2690,7 +2690,7 @@ prospect_for_resources = {
 						tag = ROOT
 						is_subject_of = ROOT
 					}
-					has_full_control_of_state = PREV
+					#has_full_control_of_state = PREV
 				}
 			}
 		}

--- a/common/national_focus/japan.txt
+++ b/common/national_focus/japan.txt
@@ -1767,12 +1767,52 @@ focus_tree = {
 
 		available = {
 			OR = {
-				has_full_control_of_state = 333
-				has_full_control_of_state = 672
-				has_full_control_of_state = 334
+				333 = { #Borneo
+					controller = {
+						OR = {
+							tag = ROOT
+							is_subject_of = ROOT
+						}
+						#has_full_control_of_state = PREV
+					}
+				}
+				334 = { #Borneo
+					controller = {
+						OR = {
+							tag = ROOT
+							is_subject_of = ROOT
+						}
+						#has_full_control_of_state = PREV
+					}
+				}
+				672 = { #Sumatra
+					controller = {
+						OR = {
+							tag = ROOT
+							is_subject_of = ROOT
+						}
+						#has_full_control_of_state = PREV
+					}
+				}
 			}
-			has_full_control_of_state = 336
-			has_full_control_of_state = 671
+			336 = { #Singapur
+				controller = {
+					OR = {
+						tag = ROOT
+						is_subject_of = ROOT
+					}
+					has_full_control_of_state = PREV
+				}
+			}
+			671 = { #Tonkin(Vietnam)
+				controller = {
+					OR = {
+						tag = ROOT
+						is_subject_of = ROOT
+					}
+					has_full_control_of_state = PREV
+				}
+			}
 		}
 
 		bypass = {

--- a/localisation/ihmp_decisions_l_english.yml
+++ b/localisation/ihmp_decisions_l_english.yml
@@ -5,7 +5,7 @@
  FRA_move_government_to_Brazzaville:0 "Moves the capital of France to Brazzaville. Possible as long as Brazzaville  is controlled by France, France itself capitulated and Algiers isn't controlled by France anymore."
  FRA_move_government_to_Bordeaux:0 "Moves the capital of France from Paris to Boredeaux."
  FRA_move_government_to_Paris:0 "Moves the capital of France back to Paris."
- SOV_sue_for_peace_FIN:0 "Offer Peace to Finland."
+ JAP_develop_east_indies_oil:0 "Expand the oil industry on Indonesia"
  SOV_sue_for_peace_FIN:0 "Offer Peace to Finland."
  SOV_relocate_industry_from_kiev:0 "Relocate Industry from Kiev"
  SOV_relocate_industry_from_kiev_desc:0 "Evacuating the heavy machinery of our Kiev factories to the Urals is a huge undertaking, but it is necessary to secure our war production."

--- a/localisation/ihmp_decisions_l_german.yml
+++ b/localisation/ihmp_decisions_l_german.yml
@@ -5,6 +5,7 @@
  FRA_move_government_to_Brazzaville:0 "Verlegt die Hauptstadt von Frankreich nach Brazzaville. Möglich solange Brazzaville von Frankreich kontrolliert wird, Frankreich kapituliert ha, sowie Algiers nichtmehr von Frankreich kontrolliert ist."
  FRA_move_government_to_Bordeaux:0 "Verlegt die Hauptstadt von Paris nach Boredeaux."
  FRA_move_government_to_Paris:0 "Verlegt die Hauptstadt von Frankreich zurück nach Paris."
+ JAP_develop_east_indies_oil:0 "Ölindustrie von Indonesien ausbauen"
  SOV_sue_for_peace_FIN:0 "Finland einen Frieden vorschlagen."
  SOV_relocate_industry_from_kiev:0 "Relocate Industry from Kiev"
  SOV_relocate_industry_from_kiev_desc:0 "Evacuating the heavy machinery of our Kiev factories to the Urals is a huge undertaking, but it is necessary to secure our war production."


### PR DESCRIPTION
- Made the Japanese "Exploit Southern Ressource Area" national focus more available, by allowing the states to be also controlled by subjects of Japan (Siam) and removing full controll conditions for Indonesia (still needs full control for Singapur and Tonkin)
- Removed the full control conditions of Borneo, Sumatra and Java from the excavate decision, should be fine if they just control the capitals of the states.