### PR TITLE
Changed Soryu Carrier Engine to Level 2

### DIFF
--- a/history/countries/JAP - Japan.txt
+++ b/history/countries/JAP - Japan.txt
@@ -1024,7 +1024,7 @@ if = {
 				fixed_ship_deck_slot_2 = ship_deck_space
 				fixed_ship_anti_air_slot = ship_anti_air_1
 				fixed_ship_radar_slot = empty
-				fixed_ship_engine_slot = carrier_ship_engine_1
+				fixed_ship_engine_slot = carrier_ship_engine_2
 				fixed_ship_secondaries_slot = ship_secondaries_1
 				front_1_custom_slot = ship_deck_space
 			}


### PR DESCRIPTION
Minimal Naval Change for Japan, before reviewing the rest.
Just makes the Japanese Soryu Class Carriers realistically fast, and allows me to reduce the required templates for carriers.